### PR TITLE
Fix standalone stratup

### DIFF
--- a/src/main/java/digital/slovensko/autogram/core/LaunchParameters.java
+++ b/src/main/java/digital/slovensko/autogram/core/LaunchParameters.java
@@ -64,7 +64,7 @@ public class LaunchParameters {
                 params = named;
             }
 
-            return new LaunchParameters(params, urlParam == null);
+            return new LaunchParameters(params, urlParam == null || urlParam.isBlank());
 
         } catch (URISyntaxException e) {
             throw new RuntimeException(e); // TODO: handle exception

--- a/src/main/scripts/resources/Autogram.template.desktop
+++ b/src/main/scripts/resources/Autogram.template.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=APPLICATION_NAME
 Comment=APPLICATION_DESCRIPTION
-Exec=APPLICATION_LAUNCHER --url='%u'
+Exec=APPLICATION_LAUNCHER --url=%u
 Icon=APPLICATION_ICON
 Terminal=false
 Type=Application


### PR DESCRIPTION
Na linuxe nikdy nefungoval standalone startup - vždy sa to spustilo minimalizované.

Pozeral som .desktop fiels iných aplikácií a nikto nepoužíva úvodzovky okolo %u parametra a prežili. Skúšal som spúšťať s `--url=` (čiže nič) a funguje ok. Problém bol doteraz ten, že ak %u bolo prázdne, Autogram dostal `--url=''`, čiže normálne url string nebol prázdny, ale boli v ňom tie single quotes `''`.