### PR TITLE
Fallback pri pokazenej xslt na vstupe

### DIFF
--- a/src/main/java/digital/slovensko/autogram/core/SigningParameters.java
+++ b/src/main/java/digital/slovensko/autogram/core/SigningParameters.java
@@ -77,9 +77,13 @@ public class SigningParameters {
 
                 throw new RuntimeException("Unsupported transformation output method: " + method);
 
-        } catch (SAXException | IOException | ParserConfigurationException e) {
+        } catch (IOException | ParserConfigurationException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
+        } catch (SAXException e) {
+            // TODO log error in more JAVA way
+            System.out.println("Error parsing transformation");
+            return null;
         }
 
         return MimeType.TEXT;

--- a/src/main/java/digital/slovensko/autogram/core/XDCTransformer.java
+++ b/src/main/java/digital/slovensko/autogram/core/XDCTransformer.java
@@ -43,7 +43,8 @@ public class XDCTransformer {
     public static XDCTransformer buildFromSigningParameters(SigningParameters sp) {
         var mediaType = DestinationMediaType.TXT;
 
-        if (sp.getTransformationOutputMimeType().equals(MimeType.HTML))
+        var outputMime = sp.getTransformationOutputMimeType();
+        if (outputMime != null && outputMime.equals(MimeType.HTML))
             mediaType = DestinationMediaType.HTML;
 
         return new XDCTransformer(sp.getIdentifier(), sp.getSchema(), sp.getTransformation(), sp.getContainerXmlns(),


### PR DESCRIPTION
@jsuchal Ten parser tiež loguje nejaký error už sám o sebe. Takto vyzerá sample výstup:
```
[Fatal Error] :68:3: The element type "xsl:template" must be terminated by the matching end-tag "</xsl:template>".
Error parsing transformation
```
