### PR TITLE
Try fixing build for windows

### DIFF
--- a/src/main/scripts/package.sh
+++ b/src/main/scripts/package.sh
@@ -27,7 +27,7 @@ while read -r key value; do
 done <"$resourcesDir/build.properties"
 unset IFS
 
-jvmOptions="--add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED"
+jvmOptions="-Dfile.encoding=UTF-8 --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED"
 arguments=(
     "--input" "$appDirectory"
     "--runtime-image" "$jdkDirectory"


### PR DESCRIPTION
Toto bolo fakt krute. V transform sa hltali vynimky, ale ked som pustil jar priamo tak sa to spravalo rovnako. Intellij a VS Code (asi) standardne spustaju apps s utf-8 encoding a niekde sa nam v tom transform deje magic. Toto je pre mna spanielska dedina, cize som to fixol nakoniec na drevorubaca v packagingu.

Mozno @sabomichal bude vediet co je zle v `transform()` metode.