### PR TITLE
AG-88 Zobrazenie certifikatu pred podpisom

### DIFF
--- a/src/main/java/digital/slovensko/autogram/core/errors/SigningCanceledByUserException.java
+++ b/src/main/java/digital/slovensko/autogram/core/errors/SigningCanceledByUserException.java
@@ -2,6 +2,6 @@ package digital.slovensko.autogram.core.errors;
 
 public class SigningCanceledByUserException extends AutogramException {
     public SigningCanceledByUserException() {
-        super(null, null, null); // TODO make this nice
+        super("Podpisovanie zrušené", "Používateľ zrušil podpisovanie", null); // TODO make this nice
     }
 }

--- a/src/main/java/digital/slovensko/autogram/ui/gui/GUI.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/GUI.java
@@ -1,6 +1,5 @@
 package digital.slovensko.autogram.ui.gui;
 
-import digital.slovensko.autogram.core.Autogram;
 import digital.slovensko.autogram.core.errors.*;
 import digital.slovensko.autogram.ui.UI;
 import digital.slovensko.autogram.core.*;
@@ -57,7 +56,8 @@ public class GUI implements UI {
             // short-circuit if only one driver present
             callback.accept(drivers.get(0));
         } else {
-            PickDriverDialogController controller = new PickDriverDialogController(drivers, callback);
+            PickDriverDialogController controller =
+                    new PickDriverDialogController(drivers, callback);
             var root = GUIUtils.loadFXML(controller, "pick-driver-dialog.fxml");
 
             var stage = new Stage();
@@ -92,7 +92,8 @@ public class GUI implements UI {
     }
 
     @Override
-    public void pickKeyAndThen(List<DSSPrivateKeyEntry> keys, Consumer<DSSPrivateKeyEntry> callback) {
+    public void pickKeyAndThen(List<DSSPrivateKeyEntry> keys,
+            Consumer<DSSPrivateKeyEntry> callback) {
         if (keys.isEmpty()) {
             showError(new NoKeysDetectedException());
             refreshKeyOnAllJobs();
@@ -131,6 +132,19 @@ public class GUI implements UI {
 
         GUIUtils.suppressDefaultFocus(stage, controller);
 
+        stage.show();
+    }
+
+    public void showKey() {
+        var controller = new ShowKeyController(this);
+        var root = GUIUtils.loadFXML(controller, "show-key-dialog.fxml");
+
+        var stage = new Stage();
+        stage.setTitle("Detaily certifikátu");
+        stage.setScene(new Scene(root));
+        stage.setResizable(true);
+        stage.initModality(Modality.APPLICATION_MODAL);
+        GUIUtils.suppressDefaultFocus(stage, controller);
         stage.show();
     }
 
@@ -196,7 +210,7 @@ public class GUI implements UI {
     @Override
     public void onSigningFailed(AutogramException e) {
         showError(e);
-        if(e instanceof TokenRemovedException) {
+        if (e instanceof TokenRemovedException) {
             resetSigningKey();
         } else {
             refreshKeyOnAllJobs();
@@ -231,7 +245,8 @@ public class GUI implements UI {
     }
 
     public void setActiveSigningKey(SigningKey newKey) {
-        if (activeKey != null) activeKey.close();
+        if (activeKey != null)
+            activeKey.close();
         activeKey = newKey;
         refreshKeyOnAllJobs();
     }

--- a/src/main/java/digital/slovensko/autogram/ui/gui/ShowKeyController.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/ShowKeyController.java
@@ -1,0 +1,62 @@
+package digital.slovensko.autogram.ui.gui;
+
+import digital.slovensko.autogram.util.DSSUtils;
+import javafx.fxml.FXML;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
+import javafx.stage.Stage;
+
+import javax.naming.InvalidNameException;
+
+public class ShowKeyController implements SuppressedFocusController {
+    @FXML
+    VBox mainBox;
+
+    @FXML
+    Text heading;
+
+    @FXML
+    Text subheading;
+
+    @FXML
+    Text description;
+
+    @FXML
+    Button showErrorDetailsButton;
+
+    GUI gui;
+
+    public ShowKeyController(GUI gui) {
+        this.gui = gui;
+    }
+
+    public void initialize() {
+        var key = this.gui.getActiveSigningKey();
+        subheading.setText(DSSUtils.parseCN(key.getCertificate().getSubject().getRFC2253()));
+        try {
+            var cert = key.getCertificate();
+            description.setText("""
+                    DN: %s
+
+                    Subject: %s
+
+                    Issuer: %s
+                    """.formatted(key.prettyPrintCertificateDetails(),
+                    cert.getSubject().getCanonical(), cert.getIssuer().getCanonical()));
+        } catch (InvalidNameException e) {
+            description.setText("Nepodarilo sa získať detaily certifikátu.");
+        }
+
+    }
+
+    public void onMainButtonAction() {
+        ((Stage) mainBox.getScene().getWindow()).close();
+    }
+
+    @Override
+    public Node getNodeForLoosingFocus() {
+        return mainBox;
+    }
+}

--- a/src/main/java/digital/slovensko/autogram/ui/gui/SigningDialogController.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/SigningDialogController.java
@@ -43,6 +43,8 @@ public class SigningDialogController implements SuppressedFocusController {
     public Button mainButton;
     @FXML
     public Button changeKeyButton;
+    @FXML
+    public Button showKeyButton;
 
     public SigningDialogController(SigningJob signingJob, Autogram autogram, GUI gui) {
         this.signingJob = signingJob;
@@ -83,6 +85,9 @@ public class SigningDialogController implements SuppressedFocusController {
         gui.resetSigningKey();
         autogram.pickSigningKeyAndThen(gui::setActiveSigningKey);
     }
+    public void onShowKeyButtonPressed(ActionEvent event){
+        gui.showKey();
+    }
 
     public void refreshSigningKey() {
         mainButton.setDisable(false);
@@ -91,10 +96,14 @@ public class SigningDialogController implements SuppressedFocusController {
             mainButton.setText("Vybrať podpisový certifikát");
             mainButton.getStyleClass().add("autogram-button--secondary");
             changeKeyButton.setVisible(false);
+            showKeyButton.setVisible(false);
+            showKeyButton.setManaged(false);
         } else {
             mainButton.setText("Podpísať ako " + DSSUtils.parseCN(key.getCertificate().getSubject().getRFC2253()));
             mainButton.getStyleClass().removeIf(style -> style.equals("autogram-button--secondary"));
             changeKeyButton.setVisible(true);
+            showKeyButton.setVisible(true);
+            showKeyButton.setManaged(true);
         }
     }
 

--- a/src/main/resources/digital/slovensko/autogram/ui/gui/idsk.css
+++ b/src/main/resources/digital/slovensko/autogram/ui/gui/idsk.css
@@ -514,3 +514,14 @@ TextFlow.autogram-body-s {
 .autogram-unsupported-visualization .autogram-error-summary__error {
     -fx-padding: 0.5em 2em 0 2em;
 }
+
+.autogram-show-key {
+    -fx-background-image: url('Autogram.png');
+    -fx-background-size: 50px 50px;
+    -fx-background-position: center;
+    -fx-background-repeat: no-repeat;
+}
+
+.autogram-show-key:hover {
+    -fx-cursor: hand;
+}

--- a/src/main/resources/digital/slovensko/autogram/ui/gui/show-key-dialog.fxml
+++ b/src/main/resources/digital/slovensko/autogram/ui/gui/show-key-dialog.fxml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<?import javafx.scene.text.Text?>
+<?import javafx.scene.text.TextFlow?>
+
+<VBox xmlns="http://javafx.com/javafx"
+      xmlns:fx="http://javafx.com/fxml"
+      prefWidth="450" minWidth="450"
+      fx:id="mainBox">
+
+    <VBox styleClass="autogram-error-summary">
+        <TextFlow styleClass="autogram-error-summary__title"><Text fx:id="heading">Podpisový certifikát</Text></TextFlow>
+        <TextFlow styleClass="autogram-error-summary__error"><Text fx:id="subheading">Miesto pre nazov informacie</Text></TextFlow>
+        <TextFlow styleClass="autogram-error-summary__description"><Text fx:id="description">description</Text></TextFlow>
+    </VBox>
+
+    <HBox styleClass="autogram-actions">
+        <Button fx:id="mainButton" styleClass="autogram-button,autogram-button--secondary" text="Pokračovať" onAction="#onMainButtonAction"/>
+    </HBox>
+
+    <TextArea fx:id="errorDetails" styleClass="autogram-details__text" editable="false" visible="false" managed="false">Error details</TextArea>
+</VBox>

--- a/src/main/resources/digital/slovensko/autogram/ui/gui/signing-dialog.fxml
+++ b/src/main/resources/digital/slovensko/autogram/ui/gui/signing-dialog.fxml
@@ -57,5 +57,6 @@
     <HBox styleClass="autogram-actions">
         <Button fx:id="mainButton" styleClass="autogram-button,autogram-button--secondary" text="Vybrať podpisový certifikát" onAction="#onMainButtonPressed"/>
         <Button fx:id="changeKeyButton" styleClass="autogram-link" text="Zmeniť" visible="false" onAction="#onChangeKeyButtonPressed"/>
+        <Button fx:id="showKeyButton" styleClass="autogram-show-key" visible="false" managed="false" prefWidth="50" prefHeight="50" onAction="#onShowKeyButtonPressed"/>
     </HBox>
 </VBox>


### PR DESCRIPTION
- add "Show key" button to signing dialog
- adds "Show key" dialog that shows details of active key

missing
- styling of button (has placeholder icon)
- styling of dialog (is just copy of error screen)
- better description of certificate