### PR TITLE
MacOS: Option to skip TLS certificate creation for Safari

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       matrix:
         config:
-          - os: ubuntu-latest
+          # - os: ubuntu-latest
           - os: macos-latest
-          - os: windows-latest
+          # - os: windows-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       matrix:
         config:
-          # - os: ubuntu-latest
+          - os: ubuntu-latest
           - os: macos-latest
-          # - os: windows-latest
+          - os: windows-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -93,7 +93,7 @@
 
     {
       "label": "MacOS: Send package for notarization",
-      "command": "xcrun notarytool submit --keychain-profile \"autogram\" --keychain $APPLE_KEYCHAIN_PATH --wait target/Autogram-*.pkg",
+      "command": "pkgutil --check-signature target/Autogram-*.pkg && xcrun notarytool submit --keychain-profile \"autogram\" --keychain $APPLE_KEYCHAIN_PATH --wait target/Autogram-*.pkg",
       "options": {
         "env": {
           "JAVA_HOME": "${config:java.jdt.ls.java.home}",

--- a/src/main/scripts/package.sh
+++ b/src/main/scripts/package.sh
@@ -167,6 +167,7 @@ if [[ "$platform" == "mac" ]]; then
     fi
 
     if [[ "$properties_mac_sign" == "1" ]]; then
+        export JPACKAGE_MAC_SIGN="1"
         if [[ -z "$APPLE_DEVELOPER_IDENTITY" ]] || [[ -z "$APPLE_KEYCHAIN_PATH" ]]; then
             echo "Missing APPLE_DEVELOPER_IDENTITY or APPLE_KEYCHAIN_PATH env variable"
             exit 1

--- a/src/main/scripts/resources/Autogram-post-image.sh
+++ b/src/main/scripts/resources/Autogram-post-image.sh
@@ -11,5 +11,7 @@ chmod +x "$TARGET/MacOS/Autogram"
 
 # codesign changed executables
 ENTITLEMENTS=../../Autogram.entitlements
-codesign -s "$APPLE_DEVELOPER_IDENTITY" --keychain $APPLE_KEYCHAIN_PATH --entitlements "$ENTITLEMENTS" --options=runtime --deep --timestamp --force "$TARGET/MacOS/Autogram"
-codesign -s "$APPLE_DEVELOPER_IDENTITY" --keychain $APPLE_KEYCHAIN_PATH --entitlements "$ENTITLEMENTS" --options=runtime --deep --timestamp --force "$TARGET/MacOS/AutogramApp"
+if [ "$JPACKAGE_MAC_SIGN" = "1"]; then
+    codesign -s "$APPLE_DEVELOPER_IDENTITY" --keychain $APPLE_KEYCHAIN_PATH --entitlements "$ENTITLEMENTS" --options=runtime --deep --timestamp --force "$TARGET/MacOS/Autogram"
+    codesign -s "$APPLE_DEVELOPER_IDENTITY" --keychain $APPLE_KEYCHAIN_PATH --entitlements "$ENTITLEMENTS" --options=runtime --deep --timestamp --force "$TARGET/MacOS/AutogramApp"
+fi

--- a/src/main/scripts/resources/Autogram-post-image.sh
+++ b/src/main/scripts/resources/Autogram-post-image.sh
@@ -1,3 +1,4 @@
+#!/bin/bash -e
 TARGET="$(cd ../images/*/*/Contents;pwd)"
 SOURCE="$(cd ../../mac-launcher;pwd)"
 
@@ -11,7 +12,7 @@ chmod +x "$TARGET/MacOS/Autogram"
 
 # codesign changed executables
 ENTITLEMENTS=../../Autogram.entitlements
-if [ "$JPACKAGE_MAC_SIGN" = "1"]; then
+if [[ "$JPACKAGE_MAC_SIGN" == "1" ]]; then
     codesign -s "$APPLE_DEVELOPER_IDENTITY" --keychain $APPLE_KEYCHAIN_PATH --entitlements "$ENTITLEMENTS" --options=runtime --deep --timestamp --force "$TARGET/MacOS/Autogram"
     codesign -s "$APPLE_DEVELOPER_IDENTITY" --keychain $APPLE_KEYCHAIN_PATH --entitlements "$ENTITLEMENTS" --options=runtime --deep --timestamp --force "$TARGET/MacOS/AutogramApp"
 fi

--- a/src/main/scripts/resources/mac-launcher/Resources/Scripts/cert-functions.sh
+++ b/src/main/scripts/resources/mac-launcher/Resources/Scripts/cert-functions.sh
@@ -1,0 +1,56 @@
+function create_cert() {
+    TLS_DIR="$HOME/Library/Application Support/Autogram/tls"
+
+    osascript -e 'return display dialog "Teraz vygenerujeme Váš osobný SSL certifikát. Následne si od Vás inštalátor vyžiada heslo, aby certifikát mohol byť pridaný ako dôveryhodný pre spojenie so Safari." with icon caution'
+    if [ $? -ne 0 ]; then
+        return 0
+    fi
+
+    mkdir -p "$TLS_DIR"
+
+    # Create temp openssl configuration
+    SSL_CONFIG_TMP=$(mktemp)
+    echo "[ req ]
+req_extensions = v3_req
+x509_extensions = v3_req
+distinguished_name = dn
+prompt = no
+encrypt_key = no
+
+[ v3_req ]
+subjectAltName = @alt_names
+basicConstraints = CA:FALSE
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+
+certificatePolicies = 1.2.3.4
+
+[dn]
+C=SK
+O=SSD
+CN=loopback.autogram.slovensko.digital
+
+[CA_default]
+copy_extension=copy
+
+[alt_names]
+DNS.1=loopback.autogram.slovensko.digital
+
+" >$SSL_CONFIG_TMP
+
+    cat $SSL_CONFIG_TMP
+
+    /usr/bin/openssl req -nodes -x509 -newkey rsa:4096 -keyout "$TLS_DIR/autogram-key.pem" -out "$TLS_DIR/autogram-cert.pem" -sha256 -days 365 -config $SSL_CONFIG_TMP
+
+    /usr/bin/openssl pkcs12 -export -in "$TLS_DIR/autogram-cert.pem" -inkey "$TLS_DIR/autogram-key.pem" -out "$TLS_DIR/autogram-pkcs12-cert.p12" -name "autogram-pkcs12-cert" -passout pass:
+
+    security -v add-trusted-cert -r trustRoot -p basic -p ssl -k $HOME/Library/Keychains/login.keychain-db "$TLS_DIR/autogram-cert.pem"
+
+    # Cleanup openssl config
+    rm $SSL_CONFIG_TMP
+}
+
+function remove_cert(){
+    TLS_DIR="$HOME/Library/Application Support/Autogram/tls"
+    security delete-certificate -Z $(openssl x509 -in "$TLS_DIR/autogram-cert.pem" -outform DER | shasum -a 1 ) "$HOME/Library/Keychains/login.keychain-db"
+}

--- a/src/main/scripts/resources/mac-launcher/Resources/Scripts/create-cert.sh
+++ b/src/main/scripts/resources/mac-launcher/Resources/Scripts/create-cert.sh
@@ -1,3 +1,4 @@
-source "$(dirname \"$0\")/cert-functions.sh";
+#!/usr/bin/env bash
+source "$(dirname "$0")/cert-functions.sh";
 
-create_cert()
+create_cert

--- a/src/main/scripts/resources/mac-launcher/Resources/Scripts/create-cert.sh
+++ b/src/main/scripts/resources/mac-launcher/Resources/Scripts/create-cert.sh
@@ -1,0 +1,3 @@
+source "$(dirname \"$0\")/cert-functions.sh";
+
+create_cert()

--- a/src/main/scripts/resources/postinstall
+++ b/src/main/scripts/resources/postinstall
@@ -24,7 +24,9 @@ function sudo_create_cert() {
     sudo -u "$USER" bash -c "$FUNC; remove_cert; create_cert"
 }
 
-if [ "$AUTOGRAM_SKIP_CREATE_CERT" = "true" ]; then
+
+
+if [[ -f "$HOME/Library/Application Support/Autogram/tls/skip" ]]; then
     exit 0
 fi
 

--- a/src/main/scripts/resources/postinstall
+++ b/src/main/scripts/resources/postinstall
@@ -13,63 +13,7 @@ fi
 chmod a+rX "/Applications"
 chmod +r "/Applications/Autogram.app/Contents/app/"*.jar
 
-
-function create_cert() {
-    TLS_DIR="$HOME/Library/Application Support/Autogram/tls"
-
-    osascript -e 'return display dialog "Teraz vygenerujeme Váš osobný SSL certifikát. Následne si od Vás inštalátor vyžiada heslo, aby certifikát mohol byť pridaný ako dôveryhodný pre spojenie so Safari." with icon caution'
-    if [ $? -ne 0 ]; then
-        return 0
-    fi
-
-    mkdir -p "$TLS_DIR"
-
-    # Create temp openssl configuration
-    SSL_CONFIG_TMP=$(mktemp)
-    echo "[ req ]
-req_extensions = v3_req
-x509_extensions = v3_req
-distinguished_name = dn
-prompt = no
-encrypt_key = no
-
-[ v3_req ]
-subjectAltName = @alt_names
-basicConstraints = CA:FALSE
-keyUsage = nonRepudiation, digitalSignature, keyEncipherment
-extendedKeyUsage = serverAuth
-
-certificatePolicies = 1.2.3.4
-
-[dn]
-C=SK
-O=SSD
-CN=loopback.autogram.slovensko.digital
-
-[CA_default]
-copy_extension=copy
-
-[alt_names]
-DNS.1=loopback.autogram.slovensko.digital
-
-" >$SSL_CONFIG_TMP
-
-    cat $SSL_CONFIG_TMP
-
-    /usr/bin/openssl req -nodes -x509 -newkey rsa:4096 -keyout "$TLS_DIR/autogram-key.pem" -out "$TLS_DIR/autogram-cert.pem" -sha256 -days 365 -config $SSL_CONFIG_TMP
-
-    /usr/bin/openssl pkcs12 -export -in "$TLS_DIR/autogram-cert.pem" -inkey "$TLS_DIR/autogram-key.pem" -out "$TLS_DIR/autogram-pkcs12-cert.p12" -name "autogram-pkcs12-cert" -passout pass:
-
-    security -v add-trusted-cert -r trustRoot -p basic -p ssl -k $HOME/Library/Keychains/login.keychain-db "$TLS_DIR/autogram-cert.pem"
-
-    # Cleanup openssl config
-    rm $SSL_CONFIG_TMP
-}
-
-function remove_cert(){
-    TLS_DIR="$HOME/Library/Application Support/Autogram/tls"
-    security delete-certificate -Z $(openssl x509 -in "$TLS_DIR/autogram-cert.pem" -outform DER | shasum -a 1 ) "$HOME/Library/Keychains/login.keychain-db"
-}
+source "/Applications/Autogram.app/Contents/Resources/Scripts/cert-functions.sh";
 
 function sudo_create_cert() {
 
@@ -78,8 +22,11 @@ function sudo_create_cert() {
 
     # Run function create_cert in "unpriviledged" environment - with real user env
     sudo -u "$USER" bash -c "$FUNC; remove_cert; create_cert"
-
 }
+
+if [ "$AUTOGRAM_SKIP_CREATE_CERT" = "true" ]; then
+    exit 0
+fi
 
 sudo_create_cert
 exit 0

--- a/src/main/scripts/resources/postinstall
+++ b/src/main/scripts/resources/postinstall
@@ -3,17 +3,22 @@ set +x
 
 DEBUG=false
 
+DESTINATION=${2:-"/Applications"}
+
 if [ $DEBUG = true ]; then
     exec 3>&1 4>&2
     trap 'exec 2>&4 1>&3' 0 1 2 3
     exec 1>>"$HOME/autogram-install.log" 2>&1
 fi
 
-# chown root:wheel "/Applications"
-chmod a+rX "/Applications"
-chmod +r "/Applications/Autogram.app/Contents/app/"*.jar
+echo "Installing Autogram to $DESTINATION"
 
-source "/Applications/Autogram.app/Contents/Resources/Scripts/cert-functions.sh";
+# chown root:wheel "/Applications"
+chmod a+rX "$DESTINATION"
+chmod +r "$DESTINATION/Autogram.app/Contents/app/"*.jar
+chmod +x "$DESTINATION/Autogram.app/Contents/Resources/Scripts/create-cert.sh"
+
+source "$DESTINATION/Autogram.app/Contents/Resources/Scripts/cert-functions.sh";
 
 function sudo_create_cert() {
 


### PR DESCRIPTION
Ked sa spusta instalacia cez brew, nemoze vyzadovat interakciu.

Pridavame teda spravanie, ze ak existuje  subor`$HOME/Library/Application Support/Autogram/tls/skip` tak sa vytvaranie preskoci

takisto pridavame moznost spustit `Autogram.app/Contents/Resources/Scripts/create-cert.sh` ktory to urobi v buducnosti ak by pouzivatel chcel pouzivat rozsirenie na safari