### PR TITLE
AG-104 Update signing parameters to contain subject name

### DIFF
--- a/src/main/java/digital/slovensko/autogram/core/SigningParameters.java
+++ b/src/main/java/digital/slovensko/autogram/core/SigningParameters.java
@@ -86,6 +86,7 @@ public class SigningParameters {
 
         parameters.setSignatureLevel(getLevel());
         parameters.setDigestAlgorithm(getDigestAlgorithm());
+        parameters.setSignaturePackaging(SignaturePackaging.ENVELOPING);
         parameters.setEn319122(isEn319132());
 
         return parameters;

--- a/src/main/java/digital/slovensko/autogram/core/SigningParameters.java
+++ b/src/main/java/digital/slovensko/autogram/core/SigningParameters.java
@@ -54,13 +54,14 @@ public class SigningParameters {
         var parameters = new ASiCWithXAdESSignatureParameters();
 
         parameters.aSiC().setContainerType(getContainer());
-        parameters.setSignatureLevel(level);
+        parameters.setSignatureLevel(getLevel());
         parameters.setDigestAlgorithm(getDigestAlgorithm());
         parameters.setSigningCertificateDigestMethod(getDigestAlgorithm());
         parameters.setSignedInfoCanonicalizationMethod(getInfoCanonicalization());
         parameters.setSignedPropertiesCanonicalizationMethod(getPropertiesCanonicalization());
+        parameters.setKeyInfoCanonicalizationMethod(getKeyInfoCanonicalization());
         parameters.setEn319132(isEn319132());
-        parameters.setSignaturePackaging(packaging);
+        parameters.setAddX509SubjectName(true);
 
         return parameters;
     }
@@ -68,13 +69,14 @@ public class SigningParameters {
     public XAdESSignatureParameters getXAdESSignatureParameters() {
         var parameters = new XAdESSignatureParameters();
 
-        parameters.setSignatureLevel(level);
+        parameters.setSignatureLevel(getLevel());
         parameters.setDigestAlgorithm(getDigestAlgorithm());
         parameters.setEn319132(isEn319132());
         parameters.setSignedInfoCanonicalizationMethod(getInfoCanonicalization());
         parameters.setSignedPropertiesCanonicalizationMethod(getPropertiesCanonicalization());
-
         parameters.setSignaturePackaging(getSignaturePackaging());
+        parameters.setKeyInfoCanonicalizationMethod(getKeyInfoCanonicalization());
+        parameters.setAddX509SubjectName(true);
 
         return parameters;
     }
@@ -82,10 +84,9 @@ public class SigningParameters {
     public CAdESSignatureParameters getCAdESSignatureParameters() {
         var parameters = new CAdESSignatureParameters();
 
-        parameters.setSignatureLevel(level);
+        parameters.setSignatureLevel(getLevel());
         parameters.setDigestAlgorithm(getDigestAlgorithm());
-        parameters.setSignaturePackaging(SignaturePackaging.ENVELOPING); // TODO: seems to be the
-                                                                         // only supported value
+        parameters.setEn319122(isEn319132());
 
         return parameters;
     }
@@ -93,7 +94,7 @@ public class SigningParameters {
     public PAdESSignatureParameters getPAdESSignatureParameters() {
         var parameters = new PAdESSignatureParameters();
 
-        parameters.setSignatureLevel(level);
+        parameters.setSignatureLevel(getLevel());
         parameters.setDigestAlgorithm(getDigestAlgorithm());
         parameters.setEn319122(isEn319132());
 
@@ -103,7 +104,7 @@ public class SigningParameters {
     public ASiCWithCAdESSignatureParameters getASiCWithCAdESSignatureParameters() {
         var parameters = new ASiCWithCAdESSignatureParameters();
 
-        parameters.setSignatureLevel(level);
+        parameters.setSignatureLevel(getLevel());
         parameters.setDigestAlgorithm(getDigestAlgorithm());
         parameters.setEn319122(isEn319132());
         parameters.aSiC().setContainerType(getContainer());

--- a/src/main/java/digital/slovensko/autogram/core/visualization/DocumentVisualizationBuilder.java
+++ b/src/main/java/digital/slovensko/autogram/core/visualization/DocumentVisualizationBuilder.java
@@ -66,7 +66,7 @@ public class DocumentVisualizationBuilder {
         if (document.getMimeType().equals(MimeTypeEnum.HTML)) {
             return new HTMLVisualization(transform(), job);
         } else if (document.getMimeType().equals(MimeTypeEnum.TEXT)) {
-            return new PlainTextVisualization(transform(), job);
+            return new PlainTextVisualization(new String(document.openStream().readAllBytes()), job);
         } else if (document.getMimeType().equals(MimeTypeEnum.PDF)) {
             return new PDFVisualization(document, job);
         } else if (document.getMimeType().equals(MimeTypeEnum.JPEG)


### PR DESCRIPTION
Toto pridáva do pospisu subject name cetifikátu, lebo iný podpisovač to tam tiež dáva.

Okrem toho fixuje bug s nefunkčnou vizualizáciou txt súboru.