### PR TITLE
fix: run prerelease workflow on release.published

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,7 +1,7 @@
 name: Pre-release
 on:
   release:
-    types: [prereleased]
+    types: [published]
 jobs:
   checklist:
     runs-on: ubuntu-latest


### PR DESCRIPTION
since `prereleased` activity type will not trigger pre-releases coming from draft  https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release