### PR TITLE
split path on success dialog into multiple hyperlinks

### DIFF
--- a/src/main/java/digital/slovensko/autogram/ui/gui/SigningSuccessDialogController.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/SigningSuccessDialogController.java
@@ -6,6 +6,7 @@ import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
 
 import java.io.File;
 
@@ -16,7 +17,7 @@ public class SigningSuccessDialogController implements SuppressedFocusController
     @FXML
     Text filenameText;
     @FXML
-    Hyperlink folderPathText;
+    TextFlow successTextFlow;
     @FXML
     Node mainBox;
 
@@ -32,7 +33,20 @@ public class SigningSuccessDialogController implements SuppressedFocusController
 
     public void initialize() {
         filenameText.setText(targetFile.getName());
-        folderPathText.setText(targetFile.getParent());
+        initHyperlink();
+    }
+
+
+    public void initHyperlink() {
+        var path = targetFile.getParent().split("((?<=/|\\\\))");
+        for (int i = 0; i < path.length; i++) {
+            var hyperlink = new Hyperlink(path[i]);
+            hyperlink.getStyleClass().add("autogram-body");
+            hyperlink.getStyleClass().add("autogram-link");
+            hyperlink.getStyleClass().add("autogram-font-weight-bold");
+            hyperlink.setOnAction(this::onOpenFolderAction);
+            successTextFlow.getChildren().add(successTextFlow.getChildren().size() - 1, hyperlink);
+        }
     }
 
     public void onOpenFolderAction(ActionEvent ignored) {

--- a/src/main/resources/digital/slovensko/autogram/ui/gui/signing-success-dialog.fxml
+++ b/src/main/resources/digital/slovensko/autogram/ui/gui/signing-success-dialog.fxml
@@ -15,12 +15,11 @@
             <TextFlow styleClass="autogram-heading-m">
                 <Text styleClass="autogram-heading-m" text="Dokument bol úspešne podpísaný" />
             </TextFlow>
-            <TextFlow styleClass="autogram-body">
+            <TextFlow styleClass="autogram-body" fx:id="successTextFlow">
                 <Text styleClass="autogram-body" text="Podpísaný súbor je uložený ako "/>
                 <Text styleClass="autogram-body,autogram-font-weight-bold" fx:id="filenameText" />
                 <Text styleClass="autogram-body" text=" v&#160;priečinku " />
-                <Hyperlink styleClass="autogram-body,autogram-link,autogram-font-weight-bold"
-                    fx:id="folderPathText" onAction="#onOpenFolderAction" wrapText="true" />
+                <!-- Hyperlinks with path are inserted here-->
                 <Text styleClass="autogram-body" text="." />
             </TextFlow>
         </VBox>


### PR DESCRIPTION
<img width="612" alt="image" src="https://github.com/slovensko-digital/autogram/assets/1194439/f7cc5a86-e674-43e0-ad9d-98af06d1f762">

fixes https://github.com/slovensko-digital/autogram/issues/241