### PR TITLE
allow more VRAM for javafx

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,8 @@
             "request": "launch",
             "mainClass": "digital.slovensko.autogram.Main",
             "projectName": "autogram",
-            "preLaunchTask": "java (build): Build Workspace"
+            "preLaunchTask": "java (build): Build Workspace",
+            // "vmArgs": "-Dprism.maxvram=2G",
         },
         {
             "type": "java",

--- a/src/main/scripts/package.sh
+++ b/src/main/scripts/package.sh
@@ -27,7 +27,7 @@ while read -r key value; do
 done <"$resourcesDir/build.properties"
 unset IFS
 
-jvmOptions="-Dfile.encoding=UTF-8 --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED"
+jvmOptions="-Dfile.encoding=UTF-8 -Dprism.maxvram=2G --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED"
 arguments=(
     "--input" "$appDirectory"
     "--runtime-image" "$jdkDirectory"


### PR DESCRIPTION
toto by mohlo vyriesit problem, ze sa dokument nezobrazi

nie je to uplne systematicke riesenie, ale po zvyseni pamate pre javafx sa mi to uz nedeje

moze to zaroven znamenat ze mame nejaky memoryleak a zly error handling