### PR TITLE
FIX: Update the new ASiC exceptions to inherit from AutogramException and catch them

### DIFF
--- a/src/main/java/digital/slovensko/autogram/core/errors/MultipleOriginalDocumentsFoundException.java
+++ b/src/main/java/digital/slovensko/autogram/core/errors/MultipleOriginalDocumentsFoundException.java
@@ -1,15 +1,8 @@
 package digital.slovensko.autogram.core.errors;
 
-public class MultipleOriginalDocumentsFoundException extends RuntimeException {
+public class MultipleOriginalDocumentsFoundException extends AutogramException {
 
     public MultipleOriginalDocumentsFoundException(String description) {
-        super("Multiple original documents found");
-        this.description = description;
-    }
-
-    private String description;
-
-    public String getDescription() {
-        return description;
+        super("Chyba ASiC-E kontajnera", "Nájdených viacero dokumnetov na podpis", description);
     }
 }

--- a/src/main/java/digital/slovensko/autogram/core/errors/OriginalDocumentNotFoundException.java
+++ b/src/main/java/digital/slovensko/autogram/core/errors/OriginalDocumentNotFoundException.java
@@ -1,15 +1,8 @@
 package digital.slovensko.autogram.core.errors;
 
-public class OriginalDocumentNotFoundException extends RuntimeException {
+public class OriginalDocumentNotFoundException extends AutogramException {
 
     public OriginalDocumentNotFoundException(String description) {
-        super("Original document not found");
-        this.description = description;
-    }
-
-    private String description;
-
-    public String getDescription() {
-        return description;
+        super("Chyba ASiC-E kontajnera", "Súbor na podpis nebol nájdený", description);
     }
 }

--- a/src/main/java/digital/slovensko/autogram/core/visualization/DocumentVisualizationBuilder.java
+++ b/src/main/java/digital/slovensko/autogram/core/visualization/DocumentVisualizationBuilder.java
@@ -26,6 +26,7 @@ import digital.slovensko.autogram.core.AutogramMimeType;
 import static digital.slovensko.autogram.core.AutogramMimeType.*;
 import digital.slovensko.autogram.core.SigningJob;
 import digital.slovensko.autogram.core.SigningParameters;
+import digital.slovensko.autogram.core.errors.AutogramException;
 import digital.slovensko.autogram.util.AsicContainerUtils;
 import eu.europa.esig.dss.enumerations.MimeType;
 import eu.europa.esig.dss.enumerations.MimeTypeEnum;
@@ -55,8 +56,13 @@ public class DocumentVisualizationBuilder {
         throws IOException, ParserConfigurationException, SAXException, TransformerException {
 
         var documentToDisplay = this.document;
-        if (isAsice(documentToDisplay.getMimeType()))
-            documentToDisplay = AsicContainerUtils.getOriginalDocument(this.document);
+        if (isAsice(documentToDisplay.getMimeType())) {
+            try {
+                documentToDisplay = AsicContainerUtils.getOriginalDocument(this.document);
+            } catch (AutogramException e) {
+                return new UnsupportedVisualization(job);
+            }
+        }
 
         if (isTranformationAvailable(getTransformation()) && isDocumentSupportingTransformation(documentToDisplay)) {
 

--- a/src/main/java/digital/slovensko/autogram/util/AsicContainerUtils.java
+++ b/src/main/java/digital/slovensko/autogram/util/AsicContainerUtils.java
@@ -20,19 +20,19 @@ public class AsicContainerUtils {
         documentValidator.setCertificateVerifier(new CommonCertificateVerifier());
         var signatures = documentValidator.getSignatures();
         if (signatures.isEmpty())
-            throw new OriginalDocumentNotFoundException("No signatures in document");
+            throw new OriginalDocumentNotFoundException("V kontajneri neboli nájdené žiadne podpisy");
 
         var extractor = new ASiCWithXAdESContainerExtractor(asice);
         var aSiCContent = extractor.extract();
 
         if (aSiCContent.getAllDocuments().isEmpty())
-            throw new OriginalDocumentNotFoundException("No documents in container");
+            throw new OriginalDocumentNotFoundException("V kontajneri neboli nájdené žiadne dokumenty");
 
         if (aSiCContent.getSignedDocuments().isEmpty())
-            throw new OriginalDocumentNotFoundException("No signed documents in container");
+            throw new OriginalDocumentNotFoundException("V kontajneri neboli nájdené žiadne dokumenty na podpis");
 
         if (aSiCContent.getSignedDocuments().size() > 1)
-            throw new MultipleOriginalDocumentsFoundException("Multiple original documents found in the container");
+            throw new MultipleOriginalDocumentsFoundException("V kontajneri bolo nájdených viacero dokumentov na podpis");
 
         var originalDocument = aSiCContent.getSignedDocuments().get(0);
         if (originalDocument.getMimeType().equals(MimeTypeEnum.XML))


### PR DESCRIPTION
Pôvodne to ešte bralo ako error pri vizualizácii a ukazovalo túto obrazovku.

To ale nie je pravda, my to by design nezobrazujeme rovnako ako pri všetkých neznámych formátoch. Preto som ešte presunul tie custom exceptions pod AutogramException a odchytil ich v builderi.

![image](https://github.com/slovensko-digital/autogram/assets/12500066/d4753fdd-3641-4bd7-a4fd-23187d118fbf)
