### PR TITLE
Use warining style for pdfa warning

### DIFF
--- a/src/main/resources/digital/slovensko/autogram/ui/gui/pdfa-compliance-dialog.fxml
+++ b/src/main/resources/digital/slovensko/autogram/ui/gui/pdfa-compliance-dialog.fxml
@@ -12,15 +12,15 @@
       prefWidth="640" minWidth="450"
       fx:id="mainBox">
 
-    <VBox styleClass="autogram-error-summary">
+    <VBox styleClass="autogram-warning-summary">
         <HBox>
             <SVGPath styleClass="autogram-icon"
                 content="M14.992 22.5001C15.5308 22.5001 15.9724 22.3361 16.3168 22.0083C16.6613 21.6804 16.8335 21.247 16.8335 20.7083C16.8335 20.1695 16.664 19.7223 16.325 19.3667C15.986 19.0112 15.5471 18.8334 15.0084 18.8334C14.4696 18.8334 14.0279 19.011 13.6835 19.3661C13.3391 19.7213 13.1668 20.1683 13.1668 20.7071C13.1668 21.2459 13.3363 21.6794 13.6753 22.0077C14.0143 22.3359 14.4532 22.5001 14.992 22.5001ZM13.5335 16.6001H16.6668V7.60005H13.5335V16.6001ZM15.0136 29.1667C13.0387 29.1667 11.1929 28.7991 9.47613 28.0639C7.75937 27.3287 6.25734 26.3175 4.97003 25.0302C3.68272 23.7429 2.67147 22.2416 1.9363 20.5262C1.2011 18.8109 0.833496 16.9648 0.833496 14.988C0.833496 13.0112 1.2011 11.1636 1.9363 9.44515C2.67147 7.72675 3.68097 6.22887 4.9648 4.95152C6.24862 3.67414 7.74902 2.66288 9.466 1.91775C11.183 1.17262 13.0308 0.800049 15.0095 0.800049C16.9881 0.800049 18.838 1.17176 20.559 1.91518C22.28 2.65858 23.7784 3.66749 25.0541 4.94192C26.3298 6.21634 27.3398 7.71497 28.0839 9.43782C28.8281 11.1606 29.2002 13.0118 29.2002 14.9912C29.2002 16.9692 28.8276 18.8164 28.0825 20.5328C27.3373 22.2491 26.3261 23.7476 25.0487 25.0281C23.7713 26.3086 22.2732 27.3185 20.5543 28.0578C18.8355 28.7971 16.9886 29.1667 15.0136 29.1667Z" />
-            <TextFlow styleClass="autogram-error-summary__title">
+            <TextFlow styleClass="autogram-warning-summary__title">
                 <Text>Dokument nie je vo formáte PDF/A</Text>
             </TextFlow>
         </HBox>
-        <TextFlow styleClass="autogram-error-summary__description">
+        <TextFlow styleClass="autogram-warning-summary__description">
             <Text>Dokument, ktorý sa chystáte podpísať je vo formáte, ktorý úrady nemusia akceptovať. Zvážte, či chcete pokračovať alebo dokument pred popisovaním upravte do vyhovujúceho formátu a&#160;skúste znova.</Text>
         </TextFlow>
     </VBox>


### PR DESCRIPTION
Podľa figmy. V release to bolo ešte pomiešané s errorom a nebolo to dobré.

![image](https://github.com/slovensko-digital/autogram/assets/12500066/e3fc6d1c-571c-4441-8799-25982d9bbf7f)
