### PR TITLE
Make windows max 800px high

### DIFF
--- a/src/main/resources/digital/slovensko/autogram/ui/gui/present-signatures-dialog.fxml
+++ b/src/main/resources/digital/slovensko/autogram/ui/gui/present-signatures-dialog.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.text.TextFlow?>
 <VBox xmlns="http://javafx.com/javafx"
       xmlns:fx="http://javafx.com/fxml"
-      maxHeight="900"
+      maxHeight="800"
       prefWidth="768"
       fx:id="mainBox">
 

--- a/src/main/resources/digital/slovensko/autogram/ui/gui/signature-details.fxml
+++ b/src/main/resources/digital/slovensko/autogram/ui/gui/signature-details.fxml
@@ -9,7 +9,8 @@
 <?import javafx.scene.shape.SVGPath?>
 <VBox xmlns="http://javafx.com/javafx"
       xmlns:fx="http://javafx.com/fxml"
-      minHeight="900"
+      prefHeight="800"
+      maxHeight="800"
       minWidth="768"
       fx:id="mainBox">
 

--- a/src/main/resources/digital/slovensko/autogram/ui/gui/signing-dialog.fxml
+++ b/src/main/resources/digital/slovensko/autogram/ui/gui/signing-dialog.fxml
@@ -11,7 +11,7 @@
 <VBox xmlns="http://javafx.com/javafx"
     xmlns:fx="http://javafx.com/fxml"
     minHeight="400"
-    maxHeight="900"
+    maxHeight="800"
     minWidth="640"
     prefWidth="768"
     fx:id="mainBox">


### PR DESCRIPTION
Okná môžu byť na niektorých nastaveniach škálovania aj na FullHD obrazovke príliš vysoké, že by default nevidno tlačidlo na podpísanie. 800 doteraz nikomu nevadilo, tak tam by som dal hranicu. Pri viacerých podpisoch zostane trochu menej miesta pre dokument, ale subjetívne si myslím, že to stačí.

![Screenshot from 2023-10-10 10-28-26](https://github.com/slovensko-digital/autogram/assets/12500066/2e61da90-d132-47a0-a9f0-368b00d78fda)
