### PR TITLE
Fix README setup typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,18 +42,18 @@ Doplniť ďalšie je pomerne ľahké pokiaľ používajú PKCS#11.
 - Maven
 - Voliteľné: Visual Studio Code ako IDE alebo Intellij IDEA (stačí komunitná verzia).
 
-Odporúčame používať Liberica JDK, ktoré má v sebe JavaFX, všetko je potom jednoduchšie. Po zavolaní `mnvw initialize` by sa malo stiahnuť do `target/jdkCache`.
+Odporúčame používať Liberica JDK, ktoré má v sebe JavaFX, všetko je potom jednoduchšie. Po zavolaní `./mvnw initialize` by sa malo stiahnuť do `target/jdkCache`.
 
 
-### Build cez `mvn package`
+### Build
 
-Pripraví všetko do `./target`:
+Spustenie `./mvnw package` pripraví všetko do `./target`:
 
 - `dependency-jars/`
 - `preparedJDK/` - JLink JDK (JRE) pripravené pre bundling s aplikáciou.
 - `autogram-*.jar` - JAR s aplikáciou
 
-Následne pomocou `jpackage` vytvorí všetky spustiteľné balíčky (.msi/.exe, .dmg/.pkg, and .rpm/.deb).
+Následne pomocou `jpackage` vytvorí všetky spustiteľné balíčky (.msi/.exe, .dmg/.pkg, a .rpm/.deb).
 
 ## Autori a sponzori
 


### PR DESCRIPTION
V README je zopar chyb ohladom setupu co mozu niekoho odradit pri rozbehavani.

Zacistil som to, takze vsade sa referencuje Maven wrapper a da sa to spustit copypastou.