### PR TITLE
Upgrade pdfjs to 2.16.105

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <dss.version>5.12.1</dss.version>
         <gson.version>2.10.1</gson.version>
         <apache.httpcomponents.version>4.5.14</apache.httpcomponents.version>
-        <pdfjs.version>2.10.377</pdfjs.version>
+        <pdfjs.version>2.16.105</pdfjs.version>
         <saxon.version>12.3</saxon.version>
         <xerces.version>2.12.1</xerces.version>
         <slf4j.version>2.0.9</slf4j.version>
@@ -336,7 +336,7 @@
                             <fromDir>cmaps</fromDir>
                             <toDir>
                                 ${project.resources[0].directory}/digital/slovensko/autogram/ui/gui/vendor/pdfjs/cmaps</toDir>
-                            <!-- <skip>true</skip> -->
+                            <skipIfExists>true</skipIfExists>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
@jsuchal nejde mi to rozbehnúť s tou starou verziou, s touto to ide. Je to iba minor zmena. Najnovší major je 3.niečo. Ty si niekedy spomínal, že nejaký upgrade pdfjs nefungoval, ale neviem, či si myslel major alebo aj minor.