### PR TITLE
Oprava nespisovného slova (ekspirácia -> exspirácia)

### DIFF
--- a/src/main/java/digital/slovensko/autogram/core/errors/NoValidKeysDetectedException.java
+++ b/src/main/java/digital/slovensko/autogram/core/errors/NoValidKeysDetectedException.java
@@ -2,6 +2,6 @@ package digital.slovensko.autogram.core.errors;
 
 public class NoValidKeysDetectedException extends AutogramException {
     public NoValidKeysDetectedException() {
-        super("Nastala chyba", "Nenašli sa žiadne platné podpisové certifikáty", "V úložisku certifikátov sa pravdepodobne nenachádzajú žiadne platné podpisové certifikáty, ktoré by sa dali použiť na podpisovanie. Boli však nájdené ekspirované certifikáty, ktorými je možné podpisovať až po zmene v nastaveniach.\n\nV prípade nového občianskeho preukazu to môže znamenať, že si potrebujete certifikáty na podpisovanie cez občiansky preukaz vydať. Robí sa to pomocou obslužného softvéru eID klient.", null);
+        super("Nastala chyba", "Nenašli sa žiadne platné podpisové certifikáty", "V úložisku certifikátov sa pravdepodobne nenachádzajú žiadne platné podpisové certifikáty, ktoré by sa dali použiť na podpisovanie. Boli však nájdené exspirované certifikáty, ktorými je možné podpisovať až po zmene v nastaveniach.\n\nV prípade nového občianskeho preukazu to môže znamenať, že si potrebujete certifikáty na podpisovanie cez občiansky preukaz vydať. Robí sa to pomocou obslužného softvéru eID klient.", null);
     }
 }

--- a/src/main/java/digital/slovensko/autogram/ui/gui/PickKeyDialogController.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/PickKeyDialogController.java
@@ -45,7 +45,7 @@ public class PickKeyDialogController {
         for (var key : keys) {
             Node badge = new HBox();
             if (!key.getCertificate().isValidOn(new java.util.Date())) {
-                badge = SignatureBadgeFactory.createInfoBadge("Ekspirovaný certifikát");
+                badge = SignatureBadgeFactory.createInfoBadge("Exspirovaný certifikát");
 
                 if (!expiredCertsEnabled)
                     continue;

--- a/src/main/resources/digital/slovensko/autogram/ui/gui/settings-dialog.fxml
+++ b/src/main/resources/digital/slovensko/autogram/ui/gui/settings-dialog.fxml
@@ -163,12 +163,12 @@
                                     <VBox styleClass="left">
                                         <TextFlow>
                                             <Text styleClass="autogram-heading-s">
-                                                Povoliť podpisovanie ekspriovanými certifikátmi
+                                                Povoliť podpisovanie exspirovanými certifikátmi
                                             </Text>
                                         </TextFlow>
                                         <TextFlow>
                                             <Text styleClass="autogram-description">
-                                                Povoliť podpisovanie ekspirovanými certifikátmi a zobrazovať ich vo výbere certifikátov.
+                                                Povoliť podpisovanie exspirovanými certifikátmi a zobrazovať ich vo výbere certifikátov.
                                             </Text>
                                         </TextFlow>
                                     </VBox>


### PR DESCRIPTION
Posielam opravu nespisovaného výrazu ekspirácia na správna exspirácia. Viď Jazykovedný ústav Ľ. Štúra - https://slovnik.juls.savba.sk/?w=exspir%C3%A1cia&c=z7a0