### PR TITLE
Minor UX fixes

### DIFF
--- a/src/main/java/digital/slovensko/autogram/core/errors/TokenNotRecognizedException.java
+++ b/src/main/java/digital/slovensko/autogram/core/errors/TokenNotRecognizedException.java
@@ -2,6 +2,6 @@ package digital.slovensko.autogram.core.errors;
 
 public class TokenNotRecognizedException extends AutogramException {
     public TokenNotRecognizedException() {
-        super("Nastala chyba", "Kartu sa nepodarilo rozpoznať", "Pravdepodobne ste vybrali nespráve úložisko certifikátov a karta s ním nie je kompatibilná.\n\nUistite sa, že máte nainštalovaný správny ovládač pre daný typ karty a skúste znova.");
+        super("Nastala chyba", "Kartu sa nepodarilo rozpoznať", "Pravdepodobne ste vybrali nespráve úložisko certifikátov a karta s ním nie je kompatibilná alebo je nastavený neplatný slot karty.\n\nUistite sa, že máte nainštalovaný správny ovládač pre daný typ karty, skontrolujte nastavenia Autogramu a skúste znova.");
     }
 }

--- a/src/main/java/digital/slovensko/autogram/ui/gui/BatchDialogController.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/BatchDialogController.java
@@ -138,6 +138,8 @@ public class BatchDialogController implements SuppressedFocusController {
         changeKeyButton.setManaged(true);
         changeKeyButton.setDisable(false);
         changeKeyButton.setVisible(true);
+
+        refreshSigningKey();
     }
 
     public void close() {


### PR DESCRIPTION
1. Pri batch sign, ak sa vyberie úložisko certifikátov, ale zavriem dialóg s certifikátmi bez výberu, zobrazoval sa aj tak secondary button, že zmeníš podpisový certifikát, aj keď žiadny nebol vybratý.

2. Napr. pri Geamlto so zlým portom, to hodí aj iný error, než sme doteraz riešili. Preto som pridal text, ktorý to môže objasniť.