### PR TITLE
ci: add .deb .rpm builds in containers, update package script

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,23 +1,84 @@
 name: Package
 
 on:
+  workflow_dispatch: # manual test
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
+  linux-deb:
+    runs-on: ubuntu-latest
+    container: "debian:latest"
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Setup dependencies
+        run: |
+          apt-get -q update && apt-get -q upgrade -y
+          apt-get -q install -y openjdk-17-jdk maven binutils fakeroot wget git
+          
+      - uses: actions/checkout@v4
+
+      - name: Build artifact
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          ./mvnw versions:set -DnewVersion=$(git describe --tags --abbrev=0 | sed -r 's/^v//g')
+          
+          ./mvnw -B -C -V package
+          ls -lah ./target
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: deb
+          path: target/*.deb
+
+  linux-rpm:
+    runs-on: ubuntu-latest
+    container: "fedora:latest"
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Setup dependencies
+        run: |
+          dnf -q install -y java-17-openjdk maven rpm-build git
+
+      - uses: actions/checkout@v4
+
+      - name: Build artifact
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          ./mvnw versions:set -DnewVersion=$(git describe --tags --abbrev=0 | sed -r 's/^v//g')
+
+          ./mvnw -B -C -V package
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rpm
+          path: target/*.rpm
+
   build:
-    runs-on: ${{ matrix.config.os }}
-    environment: packaging
+    runs-on: ${{ matrix.os }}
+    needs: 
+      - linux-deb
+      - linux-rpm
     strategy:
       matrix:
-        config:
-          - os: ubuntu-latest
-          - os: macos-latest
-          - os: windows-latest
+        os:
+          - macos-latest
+          - windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: target
+
+      - name: Check artifacts
+        run: |
+          ls target
 
       - name: Update version in pom if tag pushed
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   linux-deb:
+    environment: packaging
     runs-on: ubuntu-latest
     container: "debian:latest"
     env:
@@ -34,6 +35,7 @@ jobs:
           path: target/*.deb
 
   linux-rpm:
+    environment: packaging
     runs-on: ubuntu-latest
     container: "fedora:latest"
     env:
@@ -51,6 +53,8 @@ jobs:
           ./mvnw versions:set -DnewVersion=$(git describe --tags --abbrev=0 | sed -r 's/^v//g')
 
           ./mvnw -B -C -V package
+          ls -lah ./target
+
 
       - uses: actions/upload-artifact@v4
         with:
@@ -58,6 +62,7 @@ jobs:
           path: target/*.rpm
 
   build:
+    environment: packaging
     runs-on: ${{ matrix.os }}
     needs: 
       - linux-deb
@@ -76,21 +81,10 @@ jobs:
           merge-multiple: true
           path: target
 
-      - name: Check artifacts
-        run: |
-          ls target
-
       - name: Update version in pom if tag pushed
         if: startsWith(github.ref, 'refs/tags/')
         run: ./mvnw versions:set -DnewVersion=$(git describe --tags --abbrev=0 | sed -r 's/^v//g')
         shell: bash
-
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: "17.0.7+7"
-          distribution: "liberica"
-          java-package: "jdk+fx"
 
       - name: Cache local Maven repository and JDK cache
         uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Následne pomocou `jpackage` vytvorí všetky spustiteľné balíčky (.msi/.exe
 #### Debian/Ubuntu
 
 ```sh
-sudo apt install openjdk-17-jdk git maven binutils rpm fakeroot
+sudo apt install openjdk-17-jdk maven binutils rpm fakeroot
 ```
 
 #### Fedora

--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ Doplniť ďalšie je pomerne ľahké pokiaľ používajú PKCS#11.
 
 Odporúčame používať Liberica JDK, ktoré má v sebe JavaFX, všetko je potom jednoduchšie. Po zavolaní `./mvnw initialize` by sa malo stiahnuť do `target/jdkCache`.
 
-#### Fedora
-
-```sh
-sudo dnf install rpm-build
-```
-
 ### Build
 
 Spustenie `./mvnw package` pripraví všetko do `./target`:
@@ -59,6 +53,23 @@ Spustenie `./mvnw package` pripraví všetko do `./target`:
 - `autogram-*.jar` - JAR s aplikáciou
 
 Následne pomocou `jpackage` vytvorí všetky spustiteľné balíčky (.msi/.exe, .dmg/.pkg, a .rpm/.deb).
+
+```sh
+./mvnw versions:set -DnewVersion=$(git describe --tags --abbrev=0 | sed -r 's/^v//g')
+./mvnw package
+```
+
+#### Debian/Ubuntu
+
+```sh
+sudo apt install openjdk-17-jdk git maven binutils rpm fakeroot
+```
+
+#### Fedora
+
+```sh
+sudo dnf install java-17-openjdk maven rpm-build
+```
 
 ## Autori a sponzori
 

--- a/src/main/scripts/.shellcheckrc
+++ b/src/main/scripts/.shellcheckrc
@@ -1,0 +1,1 @@
+external-sources=true

--- a/src/main/scripts/package.sh
+++ b/src/main/scripts/package.sh
@@ -1,81 +1,90 @@
-#!/bin/bash -e
-jpackage=$1
-appDirectory=$2
-jdkDirectory=$3
-resourcesDir=$4
-platform=$5
-version=$6
-output=$7
+#!/bin/bash
+
+set -e
+
+jpackage=${1}
+appDirectory=${2}
+jdkDirectory=${3}
+resourcesDir=${4}
+platform=${5}
+version=${6}
+output=${7}
 
 function checkExitCode() {
-    exitValue=$1
-    if [[ $exitValue -ne 0 ]]; then
-        exit $exitValue
+    exitValue=${1}
+    if [[ ${exitValue} -ne 0 ]]; then
+        exit "${exitValue}"
     fi
 }
 
 IFS="="
 while read -r key value; do
     # Empty lines and comments
-    if [[ -z "$key" ]] || [[ -z "$value" ]] || [[ $key == \#* ]]; then
+    if [[ -z "${key}" ]] || [[ -z "${value}" ]] || [[ ${key} == \#* ]]; then
         continue
     fi
 
-    safekey=$(echo "$key" | tr . _)
-    trimmedvalue=$(echo "$value" | sed 's/[[:space:]]*$//g' | sed 's/^[[:space:]]*//g')
-    declare "properties_$safekey=$trimmedvalue"
+    safekey=$(echo "${key}" | tr . _)
+    trimmedvalue=$(echo "${value}" | sed 's/[[:space:]]*$//g' | sed 's/^[[:space:]]*//g')
+    declare "properties_${safekey}=${trimmedvalue}"
 done <"$resourcesDir/build.properties"
 unset IFS
 
-jvmOptions="-Dfile.encoding=UTF-8 -Dprism.maxvram=2G --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED --add-exports jdk.crypto.cryptoki/sun.security.pkcs11.wrapper=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens jdk.crypto.cryptoki/sun.security.pkcs11=ALL-UNNAMED"
+jvmOptions="-Dfile.encoding=UTF-8 \
+    -Dprism.maxvram=2G \
+    --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED \
+    --add-exports jdk.crypto.cryptoki/sun.security.pkcs11.wrapper=ALL-UNNAMED \
+    --add-opens java.base/java.security=ALL-UNNAMED \
+    --add-opens jdk.crypto.cryptoki/sun.security.pkcs11=ALL-UNNAMED"
+    
 arguments=(
-    "--input" "$appDirectory"
-    "--runtime-image" "$jdkDirectory"
+    "--input" "${appDirectory}"
+    "--runtime-image" "${jdkDirectory}"
     "--main-jar" "autogram.jar"
     "--app-version" "${properties_version:-$version}"
-    "--copyright" "$properties_copyright"
-    "--vendor" "$properties_vendor"
+    "--copyright" "${properties_copyright}"
+    "--vendor" "${properties_vendor}"
     "--icon" "./Autogram.png"
-    "--license-file" "$appDirectory/LICENSE"
+    "--license-file" "${appDirectory}/LICENSE"
     "--resource-dir" "./"
-    "--dest" "$output"
-    "--description" "$properties_description"
+    "--dest" "${output}"
+    "--description" "${properties_description}"
 )
 
-if [[ "$platform" == "win" ]]; then
+if [[ "${platform}" == "win" ]]; then
     cp "./main.template.wxs" "./main.wxs"
-    sed -i -e "s/PROTOCOL_NAME/$properties_protocol/g" "./main.wxs"
+    sed -i -e "s/PROTOCOL_NAME/${properties_protocol}/g" "./main.wxs"
 
     arguments+=(
-        "--name" "$properties_name"
+        "--name" "${properties_name}"
         "--type" "msi"
         "--icon" "./Autogram.ico"
-        "--java-options" "$jvmOptions --add-opens jdk.crypto.mscapi/sun.security.mscapi=ALL-UNNAMED"
+        "--java-options" "${jvmOptions} --add-opens jdk.crypto.mscapi/sun.security.mscapi=ALL-UNNAMED"
         "--win-shortcut-prompt"
         "--win-menu"
         "--add-launcher" "autogram-cli=$resourcesDir/windows-cli-build.properties"
     )
 
-    if [[ ! -z "$properties_win_upgradeUUID" ]]; then
+    if [[ ! -z "${properties_win_upgradeUUID}" ]]; then
         arguments+=(
-            "--win-upgrade-uuid" "$properties_win_upgradeUUID"
+            "--win-upgrade-uuid" "${properties_win_upgradeUUID}"
         )
     fi
 
-    if [[ -z "$properties_win_menu" ]] || [[ "$properties_win_menu" -ne "0" ]]; then
+    if [[ -z "${properties_win_menu}" ]] || [[ "${properties_win_menu}" -ne "0" ]]; then
         arguments+=(
             "--win-menu"
             "--win-menu-group" "${properties_win_menuGroup:-$properties_vendor}"
         )
     fi
 
-    if [[ "$properties_win_perUserInstall" == "1" ]]; then
+    if [[ "${properties_win_perUserInstall}" == "1" ]]; then
         arguments+=(
             "--win-per-user-install"
         )
     fi
 
-    if [[ "$properties_win_shortcut" == "1" ]]; then
+    if [[ "${properties_win_shortcut}" == "1" ]]; then
         arguments+=(
             "--win-shortcut"
         )
@@ -89,65 +98,67 @@ if [[ "$platform" == "linux" ]]; then
     cp "./autogram.template.desktop" "./autogram.desktop"
     sed -i -e "s/PROTOCOL_NAME/$properties_protocol/g" "./autogram.desktop"
 
-    if [[ ! -z "$properties_linux_debMaintainer" ]]; then
+    if [[ ! -z "${properties_linux_appCategory}" ]]; then
         arguments+=(
-            "--linux-deb-maintainer" "$properties_linux_debMaintainer"
+            "--linux-app-category" "${properties_linux_appCategory}"
         )
     fi
 
-    if [[ ! -z "$properties_linux_appCategory" ]]; then
+    if [[ ! -z "${properties_linux_packageDeps}" ]]; then
         arguments+=(
-            "--linux-app-category" "$properties_linux_appCategory"
-        )
-    fi
-
-    if [[ ! -z "$properties_linux_packageDeps" ]]; then
-        arguments+=(
-            "--linux-package-deps" "$properties_linux_packageDeps"
+            "--linux-package-deps" "${properties_linux_packageDeps}"
         )
     fi
 
     lowercase_name=$(echo "$properties_name" | tr '[:upper:]' '[:lower:]')
 
     arguments+=(
-        "--name" "$lowercase_name"
-        "--java-options" "$jvmOptions"
-        "--linux-rpm-license-type" "${properties_linux_rpmLicenseType:-MIT}"
+        "--name" "${lowercase_name}"
+        "--java-options" "${jvmOptions}"
         "--linux-menu-group" "${properties_linux_menuGroup:-Office}"
-        "--install-dir" "$properties_linux_installDir"
+        "--install-dir" "${properties_linux_installDir}"
     )
 
-    if [[ "$properties_linux_shortcut" == "1" ]]; then
+    if [[ "${properties_linux_shortcut}" == "1" ]]; then
         arguments+=(
             "--linux-shortcut"
         )
     fi
 
-    # Build both .rpm and .deb from Linux - should work from Debian-like distro but not the other way around
-    arguments+=(
-        "--type" "rpm"
-    )
-    $jpackage "${arguments[@]}"
-    checkExitCode $?
+    # Load variables of distribution
+    . /etc/os-release
 
-    if [[ -f "/etc/lsb-release" ]]; then
+    if [ "${ID}" == "fedora" ]; then
+        arguments+=(
+            "--type" "rpm"
+            "--linux-rpm-license-type" "${properties_linux_rpmLicenseType:-MIT}"
+        )
+    fi
+
+    if [ "${ID}" == "debian" ]; then
         arguments+=(
             "--type" "deb"
         )
-        $jpackage "${arguments[@]}"
-        checkExitCode $?
+        if [[ ! -z "${properties_linux_debMaintainer}" ]]; then
+            arguments+=(
+                "--linux-deb-maintainer" "${properties_linux_debMaintainer}"
+            )
+        fi
     fi
+
+    $jpackage "${arguments[@]}"
+    checkExitCode $?
 fi
 
-if [[ "$platform" == "mac" ]]; then
+if [[ "${platform}" == "mac" ]]; then
     cp "./Info.plist.template" "./Info.plist"
     sed -i.bak "s/PROTOCOL_NAME/$properties_protocol/g" "./Info.plist" && rm "./Info.plist.bak"
 
     arguments+=(
-        "--name" "$properties_name"
+        "--name" "${properties_name}"
         "--type" "pkg"
         "--icon" "./Autogram.icns"
-        "--java-options" "$jvmOptions"
+        "--java-options" "${jvmOptions}"
         "--mac-app-category" "${properties_mac_appCategory:-business}"
         "--mac-entitlements" "./Autogram.entitlements"
         # Building on mac requires modifying of image files
@@ -155,30 +166,30 @@ if [[ "$platform" == "mac" ]]; then
         "--temp" "./DTempFiles"
     )
 
-    if [[ ! -z "$properties_mac_identifier" ]]; then
+    if [[ ! -z "${properties_mac_identifier}" ]]; then
         arguments+=(
-            "--mac-package-identifier" "$properties_mac_identifier"
+            "--mac-package-identifier" "${properties_mac_identifier}"
         )
     fi
 
-    if [[ ! -z "$properties_mac_name" ]]; then
+    if [[ ! -z "${properties_mac_name}" ]]; then
         arguments+=(
-            "--mac-package-name" "$properties_mac_name"
+            "--mac-package-name" "${properties_mac_name}"
         )
     fi
 
     if [[ "$properties_mac_sign" == "1" ]]; then
         export JPACKAGE_MAC_SIGN="1"
-        if [[ -z "$APPLE_DEVELOPER_IDENTITY" ]] || [[ -z "$APPLE_KEYCHAIN_PATH" ]]; then
+        if [[ -z "${APPLE_DEVELOPER_IDENTITY}" ]] || [[ -z "${APPLE_KEYCHAIN_PATH}" ]]; then
             echo "Missing APPLE_DEVELOPER_IDENTITY or APPLE_KEYCHAIN_PATH env variable"
             exit 1
         fi
 
-        mac_signingKeyUserName=$(echo $APPLE_DEVELOPER_IDENTITY | sed -ne 's/Developer ID Application\:[[:space:]]\(.*\)[[:space:]]([0-9A-Z]*)/\1/p')
+        mac_signingKeyUserName=$(echo ${APPLE_DEVELOPER_IDENTITY} | sed -ne 's/Developer ID Application\:[[:space:]]\(.*\)[[:space:]]([0-9A-Z]*)/\1/p')
         arguments+=(
             "--mac-sign"
-            "--mac-signing-keychain" "$APPLE_KEYCHAIN_PATH"
-            "--mac-signing-key-user-name" "$mac_signingKeyUserName"
+            "--mac-signing-keychain" "${APPLE_KEYCHAIN_PATH}"
+            "--mac-signing-key-user-name" "${mac_signingKeyUserName}"
         )
     fi
 

--- a/src/main/scripts/package.sh
+++ b/src/main/scripts/package.sh
@@ -27,7 +27,7 @@ while read -r key value; do
     safekey=$(echo "${key}" | tr . _)
     trimmedvalue=$(echo "${value}" | sed 's/[[:space:]]*$//g' | sed 's/^[[:space:]]*//g')
     declare "properties_${safekey}=${trimmedvalue}"
-done <"$resourcesDir/build.properties"
+done < "${resourcesDir}/build.properties"
 unset IFS
 
 jvmOptions="-Dfile.encoding=UTF-8 \
@@ -65,7 +65,7 @@ if [[ "${platform}" == "win" ]]; then
         "--add-launcher" "autogram-cli=$resourcesDir/windows-cli-build.properties"
     )
 
-    if [[ ! -z "${properties_win_upgradeUUID}" ]]; then
+    if [[ -n "${properties_win_upgradeUUID}" ]]; then
         arguments+=(
             "--win-upgrade-uuid" "${properties_win_upgradeUUID}"
         )
@@ -98,19 +98,19 @@ if [[ "$platform" == "linux" ]]; then
     cp "./autogram.template.desktop" "./autogram.desktop"
     sed -i -e "s/PROTOCOL_NAME/$properties_protocol/g" "./autogram.desktop"
 
-    if [[ ! -z "${properties_linux_appCategory}" ]]; then
+    if [[ -n "${properties_linux_appCategory}" ]]; then
         arguments+=(
             "--linux-app-category" "${properties_linux_appCategory}"
         )
     fi
 
-    if [[ ! -z "${properties_linux_packageDeps}" ]]; then
+    if [[ -n "${properties_linux_packageDeps}" ]]; then
         arguments+=(
             "--linux-package-deps" "${properties_linux_packageDeps}"
         )
     fi
 
-    lowercase_name=$(echo "$properties_name" | tr '[:upper:]' '[:lower:]')
+    lowercase_name=$(echo "${properties_name}" | tr '[:upper:]' '[:lower:]')
 
     arguments+=(
         "--name" "${lowercase_name}"
@@ -131,7 +131,6 @@ if [[ "$platform" == "linux" ]]; then
     if [ "${ID}" == "fedora" ]; then
         arguments+=(
             "--type" "rpm"
-            "--linux-rpm-license-type" "${properties_linux_rpmLicenseType:-MIT}"
         )
     fi
 
@@ -139,7 +138,7 @@ if [[ "$platform" == "linux" ]]; then
         arguments+=(
             "--type" "deb"
         )
-        if [[ ! -z "${properties_linux_debMaintainer}" ]]; then
+        if [[ -n "${properties_linux_debMaintainer}" ]]; then
             arguments+=(
                 "--linux-deb-maintainer" "${properties_linux_debMaintainer}"
             )
@@ -152,7 +151,7 @@ fi
 
 if [[ "${platform}" == "mac" ]]; then
     cp "./Info.plist.template" "./Info.plist"
-    sed -i.bak "s/PROTOCOL_NAME/$properties_protocol/g" "./Info.plist" && rm "./Info.plist.bak"
+    sed -i.bak "s/PROTOCOL_NAME/${properties_protocol}/g" "./Info.plist" && rm "./Info.plist.bak"
 
     arguments+=(
         "--name" "${properties_name}"
@@ -166,19 +165,19 @@ if [[ "${platform}" == "mac" ]]; then
         "--temp" "./DTempFiles"
     )
 
-    if [[ ! -z "${properties_mac_identifier}" ]]; then
+    if [[ -n "${properties_mac_identifier}" ]]; then
         arguments+=(
             "--mac-package-identifier" "${properties_mac_identifier}"
         )
     fi
 
-    if [[ ! -z "${properties_mac_name}" ]]; then
+    if [[ -n "${properties_mac_name}" ]]; then
         arguments+=(
             "--mac-package-name" "${properties_mac_name}"
         )
     fi
 
-    if [[ "$properties_mac_sign" == "1" ]]; then
+    if [[ "${properties_mac_sign}" == "1" ]]; then
         export JPACKAGE_MAC_SIGN="1"
         if [[ -z "${APPLE_DEVELOPER_IDENTITY}" ]] || [[ -z "${APPLE_KEYCHAIN_PATH}" ]]; then
             echo "Missing APPLE_DEVELOPER_IDENTITY or APPLE_KEYCHAIN_PATH env variable"


### PR DESCRIPTION
https://github.com/slovensko-digital/autogram/issues/213

Pridal som build artifactov v **Debian** a **Fedora** kontajneroch, mám pocit že je to najjednoduchšie riešenie ako sa vyhnúť špeciálnym rozdielom v defaultoch distribúcií s **jpackage** a **rpm**. 

Zatiaľ som neriešil cache alebo nejakú špecialnu optimalizáciu **CI** zbytočnou abstrakciou, build je relatívne rýchli a release sa nerobí tak často.

Refaktorol som package script aby bol konzistentnejší a pridal [štandardnejšiu](https://www.freedesktop.org/software/systemd/man/latest/os-release.html#ID=) detekciu distribucie.