### PR TITLE
NA Timestamp badge fix

### DIFF
--- a/src/main/java/digital/slovensko/autogram/ui/gui/GUIValidationUtils.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/GUIValidationUtils.java
@@ -123,9 +123,15 @@ public class GUIValidationUtils {
                 isRevocationValidated = false;
 
         var isTimestampInvalid = false;
-        for (var timestamp : timestamps)
-            if (timestamp.getIndication().equals(Indication.FAILED))
+        var isTimestampIndeterminate = false;
+        for (var timestamp : timestamps) {
+            var indication = timestamp.getIndication();
+            if (indication.equals(Indication.FAILED) || indication.equals(Indication.TOTAL_FAILED))
                 isTimestampInvalid = true;
+
+            if (indication.equals(Indication.INDETERMINATE))
+                isTimestampIndeterminate = true;
+        }
 
         Node badge = null;
         if (!isValidated)
@@ -144,8 +150,7 @@ public class GUIValidationUtils {
                 createTableRow("Výsledok overenia",
                         isValidated
                                 ? validityToString(isValid, isFailed, areTLsLoaded, isRevocationValidated,
-                                        signatureQualification,
-                                        isTimestampInvalid)
+                                        signatureQualification, isTimestampInvalid, isTimestampIndeterminate)
                                 : "Prebieha overovanie"),
                 createTableRow("Certifikát", subject),
                 createTableRow("Vydavateľ", issuer),
@@ -168,7 +173,9 @@ public class GUIValidationUtils {
     }
 
     private static String validityToString(boolean isValid, boolean isFailed, boolean areTLsLoaded,
-                                           boolean isRevocationValidated, SignatureQualification signatureQualification, boolean isTimestampInvalid) {
+            boolean isRevocationValidated, SignatureQualification signatureQualification, boolean isTimestampInvalid,
+            boolean isTimestampIndeterminate) {
+
         if (isFailed || isTimestampInvalid)
             return "Neplatný";
 
@@ -178,12 +185,11 @@ public class GUIValidationUtils {
         if (!isRevocationValidated)
             return "Nepodarilo sa overiť platnosť certifikátu";
 
+        if (signatureQualification.getReadable().contains("Indeterminate") || isTimestampIndeterminate)
+            return "Predbežne platný";
+
         if (isValid)
             return "Platný";
-
-        if (signatureQualification.getReadable().contains("INDETERMINATE")
-                || signatureQualification.getReadable().contains("ndeterminate"))
-            return "Predbežne platný";
 
         return "Neznámy podpis";
     }

--- a/src/main/java/digital/slovensko/autogram/ui/gui/SignatureBadgeFactory.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/SignatureBadgeFactory.java
@@ -146,15 +146,22 @@ public abstract class SignatureBadgeFactory {
             var isQualified = timestamp.getQualificationDetails() != null;
             var isFailed = timestamp.getIndication() == Indication.TOTAL_FAILED
                     || timestamp.getIndication() == Indication.FAILED;
+            var isIndeterminate = timestamp.getIndication() == Indication.INDETERMINATE;
 
             if (isFailed)
                 flowPane.getChildren().add(createInvalidBadge("Neplatná ČP"));
+
+            else if (isIndeterminate)
+                flowPane.getChildren().add(
+                        createUnknownBadge("Neznáma ČP"));
+
             else if (isQualified)
                 flowPane.getChildren().add(
                         createValidQualifiedBadge(simple.getTimestampQualification(timestamp.getId()).getReadable()));
+
             else
-                flowPane.getChildren()
-                        .add(createUnknownBadge(simple.getTimestampQualification(timestamp.getId()).getReadable()));
+                flowPane.getChildren().add(
+                        createUnknownBadge("Neznáma ČP"));
         }
 
         return new HBox(flowPane);


### PR DESCRIPTION
Nameisto zeleného N/A badge tam bude "neznáma ČP". Okrem toho sa Indeterminate stav ČP zohľadní aj pri celkovom vyhodnotení podpisu - platný/predbežne platný/neplatný...

![Screenshot from 2024-01-12 12-45-09](https://github.com/slovensko-digital/autogram/assets/12500066/d24b438a-8a0c-4069-8b8a-e1c4fb23eead)
![Screenshot from 2024-01-12 12-45-33](https://github.com/slovensko-digital/autogram/assets/12500066/0cd57451-e8e9-433b-b228-d3cebf3e07e8)
![Screenshot from 2024-01-12 12-45-51](https://github.com/slovensko-digital/autogram/assets/12500066/e56f6e7e-61c6-4017-9af5-bc587f2941c1)
