### PR TITLE
Add T level for cades asice signatures

### DIFF
--- a/src/main/java/digital/slovensko/autogram/core/SigningJob.java
+++ b/src/main/java/digital/slovensko/autogram/core/SigningJob.java
@@ -126,6 +126,9 @@ public class SigningJob {
         signatureParameters.setCertificateChain(key.getCertificateChain());
         signatureParameters.setSignWithExpiredCertificate(true);
 
+        if (signatureParameters.getSignatureLevel().equals(SignatureLevel.CAdES_BASELINE_T))
+            service.setTspSource(getParameters().getTspSource());
+
         var dataToSign = service.getDataToSign(getDocument(), signatureParameters);
         var signatureValue = key.sign(dataToSign, jobParameters.getDigestAlgorithm());
 

--- a/src/main/java/digital/slovensko/autogram/core/SigningParameters.java
+++ b/src/main/java/digital/slovensko/autogram/core/SigningParameters.java
@@ -288,7 +288,7 @@ public class SigningParameters {
 
     public static SigningParameters buildForASiCWithCAdES(DSSDocument document, boolean signAsEn319132, TSPSource tspSource) throws AutogramException {
         return buildParameters(
-                SignatureLevel.CAdES_BASELINE_B,
+                (tspSource == null) ? SignatureLevel.CAdES_BASELINE_B : SignatureLevel.CAdES_BASELINE_T,
                 ASiCContainerType.ASiC_E, null, SignaturePackaging.ENVELOPING, DigestAlgorithm.SHA256, signAsEn319132, null,
                 null, null, null, null, "",
                 false, 640, true, null, null, document, tspSource);


### PR DESCRIPTION
Pri CAdES ASiCE sme nepridávali ČP, aj keď to bolo zapnuté.