### PR TITLE
Consider signature form on signed files instead of level

### DIFF
--- a/src/main/java/digital/slovensko/autogram/core/SigningJob.java
+++ b/src/main/java/digital/slovensko/autogram/core/SigningJob.java
@@ -187,12 +187,12 @@ public class SigningJob {
 
     private static SigningParameters getParametersForFile(FileDocument document, boolean checkPDFACompliance, SignatureLevel signatureType, boolean isEn319132, TSPSource tspSource, boolean plainXmlEnabled) {
         var level = SignatureValidator.getSignedDocumentSignatureLevel(document);
-        if (level != null) switch (level) {
-            case PAdES_BASELINE_B:
+        if (level != null) switch (level.getSignatureForm()) {
+            case PAdES:
                 return SigningParameters.buildForPDF(document, checkPDFACompliance, isEn319132, tspSource);
-            case XAdES_BASELINE_B:
+            case XAdES:
                 return SigningParameters.buildForASiCWithXAdES(document, isEn319132, tspSource, plainXmlEnabled);
-            case CAdES_BASELINE_B:
+            case CAdES:
                 return SigningParameters.buildForASiCWithCAdES(document, isEn319132, tspSource, plainXmlEnabled);
             default:
                 ;


### PR DESCRIPTION
Z tohto plynie problém pri už podpísanom CAdES ASiC-E s levelom T, čiže s časovou pečiatkou. Autogram v tom prípade prešiel až na koniec tejto funkcie a vybral default XAdES ASiC-E, čo ale nefungovalo a zlyhalo pri podpisovaní. Takto sa pri hociktorom leveli rozhodne pre správny formát.