### PR TITLE
#431 - Odchytiť exception pri spustení Autogramu

### DIFF
--- a/src/main/java/digital/slovensko/autogram/server/AutogramServer.java
+++ b/src/main/java/digital/slovensko/autogram/server/AutogramServer.java
@@ -90,6 +90,7 @@ public class AutogramServer {
 
         } catch (BindException e) {
             throw new RuntimeException("error.launchFailed.header port is already in use", e); // TODO
+
         } catch (Exception e) {
             throw new RuntimeException("error.serverNotCreated", e); // TODO
         }

--- a/src/main/java/digital/slovensko/autogram/server/AutogramServer.java
+++ b/src/main/java/digital/slovensko/autogram/server/AutogramServer.java
@@ -90,7 +90,6 @@ public class AutogramServer {
 
         } catch (BindException e) {
             throw new RuntimeException("error.launchFailed.header port is already in use", e); // TODO
-
         } catch (Exception e) {
             throw new RuntimeException("error.serverNotCreated", e); // TODO
         }

--- a/src/main/java/digital/slovensko/autogram/ui/gui/ErrorController.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/ErrorController.java
@@ -3,6 +3,7 @@ package digital.slovensko.autogram.ui.gui;
 import digital.slovensko.autogram.core.errors.AutogramException;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
+import javafx.scene.control.Button;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
@@ -11,6 +12,9 @@ public class ErrorController implements SuppressedFocusController {
 
     @FXML
     VBox mainBox;
+
+    @FXML
+    private Button mainButton;
 
     @FXML
     ErrorSummaryComponentController errorSummaryComponentController; // this is {include fx:id} + "Controller"
@@ -31,4 +35,9 @@ public class ErrorController implements SuppressedFocusController {
     public Node getNodeForLoosingFocus() {
         return mainBox;
     }
+
+    public void setMainButtonText(String text) {
+        mainButton.setText(text);
+    }
+
 }

--- a/src/main/java/digital/slovensko/autogram/ui/gui/GUI.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/GUI.java
@@ -175,21 +175,7 @@ public class GUI implements UI {
 
     @Override
     public void showError(AutogramException e) {
-        logger.debug("GUI showing error", e);
-        var controller = new ErrorController(e);
-        var root = GUIUtils.loadFXML(controller, "error-dialog.fxml");
-
-        var stage = new Stage();
-        stage.setTitle(e.getHeading());
-        stage.setScene(new Scene(root));
-
-        stage.sizeToScene();
-        stage.setResizable(false);
-        stage.initModality(Modality.APPLICATION_MODAL);
-
-        GUIUtils.suppressDefaultFocus(stage, controller);
-
-        stage.show();
+        GUIUtils.showError(e, "Pokračovať", false);
     }
 
     public void showPkcsEidWindowsDllError(AutogramException e) {

--- a/src/main/java/digital/slovensko/autogram/ui/gui/GUIApp.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/GUIApp.java
@@ -60,11 +60,11 @@ public class GUIApp extends Application {
             windowStage.show();
         } catch (Exception e) {
             //ak nastane chyba, zobrazíme chybové okno a ukončíme aplikáciu
-            final var severFinal = server; //pomocná premenná, do lambda výrazu nižšie musí vstupovať finalna premenná
+            final var serverFinal = server; //pomocná premenná, do lambda výrazu nižšie musí vstupovať finalna premenná
             Platform.runLater(() -> {
                 GUIUtils.showError(new UnrecognizedException(e), "Ukončiť",true);
-                if (severFinal != null) {
-                    new Thread(severFinal::stop).start();
+                if (serverFinal != null) {
+                    new Thread(serverFinal::stop).start();
                 }
                 Platform.exit();
             });

--- a/src/main/java/digital/slovensko/autogram/ui/gui/GUIApp.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/GUIApp.java
@@ -1,18 +1,18 @@
 package digital.slovensko.autogram.ui.gui;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-
 import digital.slovensko.autogram.core.Autogram;
-import digital.slovensko.autogram.core.DefaultDriverDetector;
 import digital.slovensko.autogram.core.LaunchParameters;
 import digital.slovensko.autogram.core.UserSettings;
+import digital.slovensko.autogram.core.errors.UnrecognizedException;
 import digital.slovensko.autogram.server.AutogramServer;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 public class GUIApp extends Application {
     private final ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1);
@@ -20,44 +20,55 @@ public class GUIApp extends Application {
 
     @Override
     public void start(Stage windowStage) throws Exception {
-        var userSettings = UserSettings.load();
-        var ui = new GUI(getHostServices(), userSettings);
-        var autogram = new Autogram(ui, userSettings);
+        AutogramServer server = null;
+        try {
+            var userSettings = UserSettings.load();
 
-        Platform.setImplicitExit(false);
-        autogram.checkForUpdate();
-        autogram.initializeSignatureValidator(scheduledExecutorService, cachedExecutorService, userSettings.getTrustedList());
+            Platform.setImplicitExit(false);
+            setUserAgentStylesheet(getClass().getResource("idsk.css").toExternalForm());
 
-        setUserAgentStylesheet(getClass().getResource("idsk.css").toExternalForm());
+            final Autogram autogram;
+            autogram = new Autogram(new GUI(getHostServices(), userSettings), userSettings);
+            autogram.checkForUpdate();
+            autogram.initializeSignatureValidator(scheduledExecutorService, cachedExecutorService, userSettings.getTrustedList());
 
-        var controller = new MainMenuController(autogram, userSettings);
-        var root = GUIUtils.loadFXML(controller, "main-menu.fxml");
+            final var params = LaunchParameters.fromParameters(getParameters());
+            final var controller = new MainMenuController(autogram, userSettings);
 
-        var scene = new Scene(root);
-
-        var params = LaunchParameters.fromParameters(getParameters());
-        var server = new AutogramServer(autogram, params.getHost(), params.getPort(), params.isProtocolHttps(), cachedExecutorService);
-
-        if (userSettings.isServerEnabled()) {
-            server.start();
-        }
-
-        windowStage.setOnCloseRequest(event -> {
+            server = new AutogramServer(autogram, params.getHost(), params.getPort(), params.isProtocolHttps(), cachedExecutorService);
             if (userSettings.isServerEnabled()) {
-                new Thread(server::stop).start();
+                server.start();
             }
 
-            Platform.exit();
-        });
 
-        if (!params.isStandaloneMode())
-            GUIUtils.startIconified(windowStage);
+            Thread thread = new Thread(server::stop);
+            windowStage.setOnCloseRequest(event -> {
+                if (userSettings.isServerEnabled()) {
+                    thread.start();
+                }
+                Platform.exit();
+            });
 
-        GUIUtils.suppressDefaultFocus(windowStage, controller);
-        windowStage.setTitle("Autogram");
-        windowStage.setScene(scene);
-        windowStage.setResizable(false);
-        windowStage.show();
+
+            if (!params.isStandaloneMode())
+                GUIUtils.startIconified(windowStage);
+
+            GUIUtils.suppressDefaultFocus(windowStage, controller);
+            windowStage.setTitle("Autogram");
+            windowStage.setScene(new Scene(GUIUtils.loadFXML(controller, "main-menu.fxml")));
+            windowStage.setResizable(false);
+            windowStage.show();
+        } catch (Exception e) {
+            //ak nastane chyba, zobrazíme chybové okno a ukončíme aplikáciu
+            final var severFinal = server; //pomocná premenná, do lambda výrazu nižšie musí vstupovať finalna premenná
+            Platform.runLater(() -> {
+                GUIUtils.showError(new UnrecognizedException(e), "Ukončiť",true);
+                if (severFinal != null) {
+                    new Thread(severFinal::stop).start();
+                }
+                Platform.exit();
+            });
+        }
     }
 
     @Override

--- a/src/main/java/digital/slovensko/autogram/ui/gui/GUIUtils.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/GUIUtils.java
@@ -1,17 +1,24 @@
 package digital.slovensko.autogram.ui.gui;
 
+import digital.slovensko.autogram.core.errors.AutogramException;
 import digital.slovensko.autogram.util.OperatingSystem;
 import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
 import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.stage.Modality;
 import javafx.stage.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
 public class GUIUtils {
+
+    private static Logger logger = LoggerFactory.getLogger(GUIUtils.class);
     static Parent loadFXML(Object controller, String fxml) {
         try {
             var loader = new FXMLLoader();
@@ -63,7 +70,6 @@ public class GUIUtils {
         }
     }
 
-
     public static String exceptionToString(Exception exception) {
         var writer = new StringWriter();
         var printWriter = new PrintWriter(writer);
@@ -79,5 +85,28 @@ public class GUIUtils {
         var w = stage.getScene().getWindow();
         // This forces layout recalculation and fixes issue https://github.com/slovensko-digital/autogram/issues/172
         w.setHeight(w.getHeight() - 1);
+    }
+
+    public static void showError(AutogramException e, String buttonText, boolean wait) {
+        logger.debug("GUI showing error", e);
+        var controller = new ErrorController(e);
+        var root = GUIUtils.loadFXML(controller, "error-dialog.fxml");
+        controller.setMainButtonText(buttonText);
+
+        var stage = new Stage();
+        stage.setTitle(e.getHeading());
+        stage.setScene(new Scene(root));
+
+        stage.sizeToScene();
+        stage.setResizable(false);
+        stage.initModality(Modality.APPLICATION_MODAL);
+
+        GUIUtils.suppressDefaultFocus(stage, controller);
+
+        if (wait) {
+            stage.showAndWait();
+        } else {
+            stage.show();
+        }
     }
 }


### PR DESCRIPTION
- ošetrenie chybového stavu pri štarte aplikácie (GUIApp.start())
- vytvorenie statickej metódy GUIUtils.showError (ako kópia pôvodnej GUI.showError, statická metóda má výhodu že sa môže volať ešte pred inicializáciou triedy GUI)
- parametrizovanie názvu button v error dialógu (ErrorController.java)