### PR TITLE
Add support for multiple TSP

### DIFF
--- a/src/main/java/digital/slovensko/autogram/core/AppStarter.java
+++ b/src/main/java/digital/slovensko/autogram/core/AppStarter.java
@@ -75,7 +75,8 @@ public class AppStarter {
                 autogram --cli -s target/directory-example -t target/non-existent-dir/output-example --parents
                 autogram --cli -s target/directory-example/file-example.pdf -pdfa
                 autogram --cli -s target/directory-example/file-example.pdf -d eid
-                autogram --cli -s target/file-example.pdf -d eid --tsa-server http://tsa.izenpe.com
+                autogram --cli -s target/file-example.pdf -d eid --tsa-server http://tsa.belgium.be/connect
+                autogram --cli -s target/file-example.pdf -d eid --tsa-server "http://tsa.belgium.be/connect,http://ts.quovadisglobal.com/eu,http://tsa.sep.bg"
                 """;
         final PrintWriter pw = new PrintWriter(System.out);
         formatter.printUsage(pw, 80, syntax);

--- a/src/main/java/digital/slovensko/autogram/core/UserSettings.java
+++ b/src/main/java/digital/slovensko/autogram/core/UserSettings.java
@@ -28,7 +28,7 @@ public class UserSettings implements PasswordManagerSettings, SignatureTokenSett
     private List<String> trustedList;
     private String customKeystorePath;
     private String tsaServer;
-    private TSPSource tspSource;
+    private CompositeTSPSource tspSource;
     private boolean tsaEnabled;
     private String customTsaServer;
     private boolean bulkEnabled;
@@ -50,7 +50,7 @@ public class UserSettings implements PasswordManagerSettings, SignatureTokenSett
         settings.setPdfaCompliance(prefs.getBoolean("PDFA_COMPLIANCE", true));
         settings.setServerEnabled(prefs.getBoolean("SERVER_ENABLED", true));
         settings.setExpiredCertsEnabled(prefs.getBoolean("EXPIRED_CERTS_ENABLED", false));
-        settings.setTrustedList(prefs.get("TRUSTED_LIST", "SK,CZ,AT,PL,HU,BE,BG"));
+        settings.setTrustedList(prefs.get("TRUSTED_LIST", "SK,CZ,AT,PL,HU,BE,NL,BG"));
         settings.setCustomKeystorePath(prefs.get("CUSTOM_KEYSTORE_PATH", ""));
         settings.setTsaServer(prefs.get("TSA_SERVER", "http://tsa.belgium.be/connect,http://ts.quovadisglobal.com/eu,http://tsa.sep.bg"));
         settings.setCustomTsaServer(prefs.get("CUSTOM_TSA_SERVER", ""));
@@ -214,8 +214,8 @@ public class UserSettings implements PasswordManagerSettings, SignatureTokenSett
             return;
         }
 
+        tspSource = new CompositeTSPSource();
         var timestampDataLoader = new TimestampDataLoader();
-        var tspSource = new CompositeTSPSource();
         var tspSources = new HashMap<String, TSPSource>();
         for (var tsaServer : tsaServer.split(","))
             tspSources.put(tsaServer, new OnlineTSPSource(tsaServer, timestampDataLoader));

--- a/src/main/java/digital/slovensko/autogram/core/UserSettings.java
+++ b/src/main/java/digital/slovensko/autogram/core/UserSettings.java
@@ -2,11 +2,14 @@ package digital.slovensko.autogram.core;
 
 import digital.slovensko.autogram.ui.gui.SignatureLevelStringConverter;
 import eu.europa.esig.dss.enumerations.SignatureLevel;
+import eu.europa.esig.dss.service.http.commons.TimestampDataLoader;
 import eu.europa.esig.dss.service.tsp.OnlineTSPSource;
+import eu.europa.esig.dss.spi.x509.tsp.CompositeTSPSource;
 import eu.europa.esig.dss.spi.x509.tsp.TSPSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.prefs.Preferences;
 
@@ -47,9 +50,9 @@ public class UserSettings implements PasswordManagerSettings, SignatureTokenSett
         settings.setPdfaCompliance(prefs.getBoolean("PDFA_COMPLIANCE", true));
         settings.setServerEnabled(prefs.getBoolean("SERVER_ENABLED", true));
         settings.setExpiredCertsEnabled(prefs.getBoolean("EXPIRED_CERTS_ENABLED", false));
-        settings.setTrustedList(prefs.get("TRUSTED_LIST", "SK,CZ,AT,PL,HU,ES,BE"));
+        settings.setTrustedList(prefs.get("TRUSTED_LIST", "SK,CZ,AT,PL,HU,BE,BG"));
         settings.setCustomKeystorePath(prefs.get("CUSTOM_KEYSTORE_PATH", ""));
-        settings.setTsaServer(prefs.get("TSA_SERVER", "http://tsa.izenpe.com"));
+        settings.setTsaServer(prefs.get("TSA_SERVER", "http://tsa.belgium.be/connect,http://ts.quovadisglobal.com/eu,http://tsa.sep.bg"));
         settings.setCustomTsaServer(prefs.get("CUSTOM_TSA_SERVER", ""));
         settings.setTsaEnabled(prefs.getBoolean("TSA_ENABLE", false));
         settings.setPdfDpi(prefs.getInt("PDF_DPI", 100));
@@ -206,11 +209,18 @@ public class UserSettings implements PasswordManagerSettings, SignatureTokenSett
 
     public void setTsaServer(String value) {
         tsaServer = value;
-        if (value == null)
+        if (value == null) {
             tspSource = null;
+            return;
+        }
 
-        else
-            tspSource = new OnlineTSPSource(tsaServer);
+        var timestampDataLoader = new TimestampDataLoader();
+        var tspSource = new CompositeTSPSource();
+        var tspSources = new HashMap<String, TSPSource>();
+        for (var tsaServer : tsaServer.split(","))
+            tspSources.put(tsaServer, new OnlineTSPSource(tsaServer, timestampDataLoader));
+
+        tspSource.setTspSources(tspSources);
     }
 
     public String getCustomTsaServer() {

--- a/src/main/java/digital/slovensko/autogram/ui/gui/SettingsDialogController.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/SettingsDialogController.java
@@ -59,9 +59,9 @@ public class SettingsDialogController {
 
     private final UserSettings userSettings;
     private final List<String> preDefinedTsaServers = List.of(
-            "http://tsa.izenpe.com",
-            "http://tsa.belgium.be/connect",
-            "http://kstamp.keynectis.com/KSign/"
+            "http://tsa.belgium.be/connect,http://ts.quovadisglobal.com/eu,http://tsa.sep.bg",
+            "http://ts.quovadisglobal.com/eu",
+            "http://tsa.sep.bg"
     );
 
     public SettingsDialogController(UserSettings userSettings) {
@@ -143,6 +143,8 @@ public class SettingsDialogController {
 
         if (!preDefinedTsaServers.contains(userSettings.getTsaServer())) {
             tsaChoiceBox.setValue(USE_CUSTOM_TSA_LABEL);
+            customTsaServerTextField.setText(userSettings.getTsaServer());
+            userSettings.setCustomTsaServer(userSettings.getTsaServer());
             return;
         }
 

--- a/src/main/resources/digital/slovensko/autogram/ui/gui/settings-dialog.fxml
+++ b/src/main/resources/digital/slovensko/autogram/ui/gui/settings-dialog.fxml
@@ -91,17 +91,17 @@
                                     <VBox styleClass="left">
                                         <TextFlow>
                                             <Text styleClass="autogram-heading-s">
-                                                Zdroj časových pečiatok
+                                                Zdroje časových pečiatok
                                             </Text>
                                         </TextFlow>
                                         <TextFlow>
                                             <Text styleClass="autogram-description">
-                                                Je možné použiť niektorý z preddefinovaných voľne dostupných poskytovateľov alebo nastaviť vlastnú adresu.
+                                                Je možné použiť preddefinovaných voľne dostupných poskytovateľov alebo nastaviť vlastné adresy.
                                             </Text>
                                         </TextFlow>
                                         <TextFlow>
                                             <Text styleClass="autogram-description">
-                                                Pre správne overenie platnosti časovej pečiatky je potrebné, aby bola TSA v zozname dôveryhodných poskytovateľov a aby krajina jej pôvodu bola nastavená v záložke "Overovanie podpisov".
+                                                Pre správne overenie platnosti časovej pečiatky je potrebné, aby bola TSA kvalifikovaná a aby krajina jej pôvodu bola nastavená v záložke "Overovanie podpisov".
                                             </Text>
                                         </TextFlow>
                                     </VBox>
@@ -113,12 +113,12 @@
                                     <VBox styleClass="left">
                                         <TextFlow>
                                             <Text styleClass="autogram-heading-s">
-                                                Vlastná adresa TSA servera
+                                                Vlastné adresy TSP serverov
                                             </Text>
                                         </TextFlow>
                                         <TextFlow>
                                             <Text styleClass="autogram-description">
-                                                URL adresa iného servera autority časových pečiatok.
+                                                URL adresy serverov poskytovateľov časových pečiatok. Viaceré adresy je možné oddeliť čiarkou bez medzier.
                                             </Text>
                                         </TextFlow>
                                     </VBox>


### PR DESCRIPTION
Rovnako ako to máme v archiveri a na AVM, pridávame možnosť nastavenia viacerých TSP naraz. Tým pádom, ak na nejakom presiahneme FUP alebo z iného dôvodu nezafunguje, použije sa ďalší zo zoznamu.