### PR TITLE
Reserve single thread executor service for server

### DIFF
--- a/src/main/java/digital/slovensko/autogram/ui/gui/GUIApp.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/GUIApp.java
@@ -16,7 +16,8 @@ import java.util.concurrent.ScheduledExecutorService;
 
 public class GUIApp extends Application {
     private final ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1);
-    private final ExecutorService cachedExecutorService = Executors.newFixedThreadPool(8);
+    private final ExecutorService cachedExecutorService = Executors.newFixedThreadPool(4);
+    private final ExecutorService serverExecutorService = Executors.newFixedThreadPool(1);
 
     @Override
     public void start(Stage windowStage) throws Exception {
@@ -35,7 +36,7 @@ public class GUIApp extends Application {
             final var params = LaunchParameters.fromParameters(getParameters());
             final var controller = new MainMenuController(autogram, userSettings);
 
-            server = new AutogramServer(autogram, params.getHost(), params.getPort(), params.isProtocolHttps(), cachedExecutorService);
+            server = new AutogramServer(autogram, params.getHost(), params.getPort(), params.isProtocolHttps(), serverExecutorService);
             if (userSettings.isServerEnabled()) {
                 server.start();
             }


### PR DESCRIPTION
Zamýšľal som sa, prečo trvá tak dlho spustiť Autogram z extension a potom zobraziť SignigDialog. V mojej konfigurácii mám zapnuté všetky trusted listy, takže SignatureValidator o to viac pečie po spustení. A dnes mi nejako napadlo, či to nebude tým, že server zdieľa thread pool so SignatureValidatorom. Skúsil som dať teda serveru osobitný thread a zrazu API odpovedá aj hneď po spustení Autogramu 🥳 

Navyše, 8 threadov pre validátor je veľa. Povedzme, že bežný PC má 8 threadov, tak toto ho celý upečie. 4 dávajú väčší zmysel.