### PR TITLE
tokenSessionTimeout - fix CLI and fix application shutdown

### DIFF
--- a/src/main/java/digital/slovensko/autogram/core/Autogram.java
+++ b/src/main/java/digital/slovensko/autogram/core/Autogram.java
@@ -273,7 +273,7 @@ public class Autogram {
         return settings.isPlainXmlEnabled();
     }
 
-    private void stopTokenSessionTimer() {
+    public void stopTokenSessionTimer() {
         if (tokenSessionTimer == null)
             return;
 

--- a/src/main/java/digital/slovensko/autogram/ui/cli/CliApp.java
+++ b/src/main/java/digital/slovensko/autogram/ui/cli/CliApp.java
@@ -8,15 +8,17 @@ import digital.slovensko.autogram.ui.SaveFileResponder;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Timer;
 
 import org.apache.commons.cli.CommandLine;
 
 public class CliApp {
     public static void start(CommandLine cmd) {
+        Autogram autogram = null;
         try {
             var settings = CliSettings.fromCmd(cmd);
             var ui = new CliUI(settings);
-            var autogram = new Autogram(ui, settings);
+            autogram = new Autogram(ui, settings);
 
             if (settings.getSource() == null)
                 throw new SourceNotDefindedException();
@@ -29,24 +31,29 @@ public class CliApp {
 
             var source = settings.getSource();
             var sourceList = source.isDirectory() ? source.listFiles() : new File[] { source };
+
+            var finalAutogram = autogram;
             var jobs = Arrays.stream(sourceList).filter(f -> f.isFile())
-                    .map(f -> SigningJob.buildFromFile(f, new SaveFileResponder(f, autogram, targetPathBuilder),
+                    .map(f -> SigningJob.buildFromFile(f, new SaveFileResponder(f, finalAutogram, targetPathBuilder),
                             settings.isPdfaCompliance(), settings.getSignatureLevel(), settings.isEn319132(),
                             settings.getTspSource(), settings.isPlainXmlEnabled()))
                     .toList();
             if (settings.isPdfaCompliance()) {
                 jobs.forEach(job -> {
                     System.out.println("Checking PDF/A file compatibility for " + job.getDocument().getName());
-                    autogram.checkPDFACompliance(job);
+                    finalAutogram.checkPDFACompliance(job);
                 });
             }
 
             ui.setJobsCount(jobs.size());
-
             jobs.forEach(autogram::sign);
+
+            autogram.stopTokenSessionTimer();
 
         } catch (AutogramException e) {
             System.err.println(CliUI.parseError(e));
+            if (autogram != null)
+                autogram.stopTokenSessionTimer();
         }
     }
 }

--- a/src/main/java/digital/slovensko/autogram/ui/cli/CliSettings.java
+++ b/src/main/java/digital/slovensko/autogram/ui/cli/CliSettings.java
@@ -34,6 +34,7 @@ public class CliSettings extends UserSettings {
         settings.setTsaEnabled(settings.getTsaServer() != null);
         settings.setBulkEnabled(true);
         settings.setPlainXmlEnabled(cmd.hasOption("plain-xml"));
+        settings.setTokenSessionTimeout(5);
 
         return settings;
     }

--- a/src/main/resources/digital/slovensko/autogram/server/server.yml
+++ b/src/main/resources/digital/slovensko/autogram/server/server.yml
@@ -13,7 +13,7 @@ info:
   license:
     name: EUPL
     url: https://github.com/slovensko-digital/autogram/blob/main/LICENSE
-  version: 2.2.0
+  version: 2.3.0
 servers:
   - url: http://localhost:37200
   - url: /

--- a/src/test/java/digital/slovensko/autogram/AutogramTests.java
+++ b/src/test/java/digital/slovensko/autogram/AutogramTests.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.security.KeyStore;
 import java.util.List;
 import java.util.Objects;
+import java.util.Timer;
 import java.util.function.Consumer;
 
 import static org.mockito.ArgumentMatchers.any;


### PR DESCRIPTION
1. Aplikácia sa dlho zatvárala, pretože ten timer tam zostal bežať.
2. V CLI bol timeout 0, takže to moc dobre nefungovalo. Zistil som inak, že v CLI nefunguje hromadné podpisovanie na 1x PIN, ale to nesúvisí s týmto, takže spíšem osobitnú issue.