### PR TITLE
Fix windows version

### DIFF
--- a/src/main/java/digital/slovensko/autogram/server/AssetsEndpoint.java
+++ b/src/main/java/digital/slovensko/autogram/server/AssetsEndpoint.java
@@ -6,8 +6,10 @@ import digital.slovensko.autogram.server.dto.ErrorResponse;
 import digital.slovensko.autogram.server.errors.InvalidUrlParamException;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
@@ -16,7 +18,11 @@ public class AssetsEndpoint implements HttpHandler {
     private static final List<String> assets;
     private static final Path assetsPath;
     static  {
-        assetsPath = Path.of(requireNonNull(AssetsEndpoint.class.getResource("index.html")).getPath()).getParent().resolve("assets");
+        try {
+            assetsPath = Paths.get(requireNonNull(AssetsEndpoint.class.getResource("index.html")).toURI()).getParent().resolve("assets");
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
         assets = List.of(
                 "swagger-ui-bundle-v5.11.0.js",
                 "swagger-ui-v5.11.0.css"

--- a/src/main/resources/digital/slovensko/autogram/build.properties
+++ b/src/main/resources/digital/slovensko/autogram/build.properties
@@ -24,7 +24,7 @@ win.menuGroup=
 win.perUserInstall=
 # Create a desktop shortcut for the application (1/0).
 # Defaults to 0.
-win.shortcut=
+win.shortcut=1
 
 ### Linux specific ###
 

--- a/src/main/scripts/package.sh
+++ b/src/main/scripts/package.sh
@@ -57,10 +57,10 @@ if [[ "${platform}" == "win" ]]; then
 
     arguments+=(
         "--name" "${properties_name}"
+        "--description" "${properties_name}"
         "--type" "msi"
         "--icon" "./Autogram.ico"
         "--java-options" "${jvmOptions} --add-opens jdk.crypto.mscapi/sun.security.mscapi=ALL-UNNAMED"
-        "--win-shortcut-prompt"
         "--win-menu"
         "--add-launcher" "autogram-cli=$resourcesDir/windows-cli-build.properties"
     )


### PR DESCRIPTION
No, ukázalo sa, že tie pathy pri assetoch na windowse nebudú ani za svet fungovať. Pôvodné riešenie v main branchi má problém, že Path.of() nevie spracovať string s dvojbodkami, čo vo Windowse bude vždy (C://nieco...). Na to som našiel iné riešenie, ale to zase fungovalo iba v developmente. Nakoniec to vyriešime tak, že máme whitelist súborov a mimetype zistíme podľa koncovky.

Keď som si už rozbehol dev prostredie na windowse (a viem aj buildovať installer!!!), pridal som desktop shortcut a zmenil som "description" packagu na "name", pretože to je to, čo sa ukazuje v prehlidači, keď ide user spúšťať Autogram z browsera. Predtým sa to usera pýtalo, či chce spsustiť aplikáciu "Opensource EIDAS compliant ...". Teraz tam bude že "Autogram".