### PR TITLE
update liberica to 17.0.15.+10

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: "17.0.7+7"
+          java-version: "17.0.15+10"
           distribution: "liberica"
           java-package: "jdk+fx"
 
@@ -129,7 +129,7 @@ jobs:
           security default-keychain -s $APPLE_KEYCHAIN_PATH
 
       - name: Package with Maven
-        run: ./mvnw -B -C -V package
+        run: ./mvnw -B -C -V package -P system-jdk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_KEYCHAIN_PATH: ${{ env.APPLE_KEYCHAIN_PATH }}
@@ -180,7 +180,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: "17.0.7+7"
+          java-version: "17.0.15+10"
           distribution: "liberica"
           java-package: "jdk+fx"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '17.0.7+7'
+          java-version: '17.0.15+10'
           distribution: 'liberica'
           java-package: 'jdk+fx'
 
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Run tests
-        run: ./mvnw test
+        run: ./mvnw test -P system-jdk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <snakeyml.version>2.4</snakeyml.version>
         <jimfs.version>1.3.0</jimfs.version>
         <testExcludedGroups>HttpSmokeTest</testExcludedGroups>
+        <skip-jdk-cache>false</skip-jdk-cache>
     </properties>
 
     <dependencyManagement>
@@ -317,6 +318,7 @@
                             <goal>cache-jdk</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip-jdk-cache}</skip>
                             <jdkPathProperty>jlink.jdk.path</jdkPathProperty>
                             <jdkCachePath>${project.build.directory}${file.separator}jdkCache</jdkCachePath>
                             <authorization>${github.auth}</authorization>
@@ -525,6 +527,14 @@
             </build>
             <properties>
                 <testExcludedGroups></testExcludedGroups>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>system-jdk</id>
+            <properties>
+                <jlink.jdk.path>${env.JAVA_HOME}</jlink.jdk.path>
+                <skip-jdk-cache>true</skip-jdk-cache>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
Na toto som narazil, že nová verzia výrazne zlepšuje Autogram minimálne na Mac OS - tam bol taký problém, že appka sa spúšťala 6 selúnd kvôli timeoutu na nejakom bugu https://bugs.openjdk.org/browse/JDK-8315657  a otvorila na pozadí. S týmto updatom sa otvára za 1 sekundu a správne.

Pri release otestujem aj Win a Linux.