### PR TITLE
Fix fedora build

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -42,14 +42,13 @@ jobs:
   linux-rpm:
     environment: packaging
     runs-on: ubuntu-latest
-    container: "fedora:latest"
+    container: "fedora:41"
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Setup dependencies
         run: |
-          dnf -q install -y java-17-openjdk rpm-build git
-          dnf -q install -y maven
+          dnf -q install -y java-17-openjdk maven-openjdk17 rpm-build git
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -48,7 +48,8 @@ jobs:
     steps:
       - name: Setup dependencies
         run: |
-          dnf -q install -y java-17-openjdk maven-openjdk17 rpm-build git
+          dnf -q install -y java-17-openjdk rpm-build git
+          dnf -q install -y maven
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
V novej fedora 42 nie sú tie repá na java 17 jdk. Dajú sa nejako pridať iné, ale jednoduchšie bude locknúť verziu fedory - buildíme potom aj tak s tou libericou.