### PR TITLE
Add bulk signing enable/disable check

### DIFF
--- a/src/main/java/digital/slovensko/autogram/core/Autogram.java
+++ b/src/main/java/digital/slovensko/autogram/core/Autogram.java
@@ -3,6 +3,7 @@ package digital.slovensko.autogram.core;
 import digital.slovensko.autogram.core.errors.AutogramException;
 import digital.slovensko.autogram.core.errors.BatchConflictException;
 import digital.slovensko.autogram.core.errors.BatchNotStartedException;
+import digital.slovensko.autogram.core.errors.BulkSigningDisabledException;
 import digital.slovensko.autogram.core.errors.CertificatesReadingConsentRejectedException;
 import digital.slovensko.autogram.core.errors.NoDriversDetectedException;
 import digital.slovensko.autogram.core.errors.PINIncorrectException;
@@ -148,6 +149,9 @@ public class Autogram {
      * @param responder              - callback for http response
      */
     public void batchStart(int totalNumberOfDocuments, BatchResponder responder) {
+        if (!settings.isBulkEnabled())
+            throw new BulkSigningDisabledException();
+
         if (batch != null && !batch.isEnded())
             throw new BatchConflictException();
         batch = new Batch(totalNumberOfDocuments);

--- a/src/main/java/digital/slovensko/autogram/core/errors/BulkSigningDisabledException.java
+++ b/src/main/java/digital/slovensko/autogram/core/errors/BulkSigningDisabledException.java
@@ -1,0 +1,7 @@
+package digital.slovensko.autogram.core.errors;
+
+public class BulkSigningDisabledException extends AutogramException {
+    public BulkSigningDisabledException() {
+        super();
+    }
+}

--- a/src/main/resources/digital/slovensko/autogram/ui/gui/language/l10n.properties
+++ b/src/main/resources/digital/slovensko/autogram/ui/gui/language/l10n.properties
@@ -50,6 +50,10 @@ error.BatchCanceledException.heading=Hromadné podpisovanie zrušené
 error.BatchCanceledException.subheading=
 error.BatchCanceledException.description=Hromadné podpisovanie už bolo zrušené a nie je možné podpisovať ďalšie dokumenty s rovnakým batchId
 
+error.BulkSigningDisabledException.heading=Hromadné podpisovanie je vypnuté
+error.BulkSigningDisabledException.subheading=Hromadné podpisovanie nie je povolené
+error.BulkSigningDisabledException.description=Hromadné podpisovanie je vypnuté v nastaveniach. Zapnite ho a skúste znova.
+
 error.BatchConflictException.heading=Iné hromadné podpisovanie už prebieha
 error.BatchConflictException.subheading=Naraz je možné vykonávať iba jedno hromadné podpisovanie
 error.BatchConflictException.description=Iné hromadné podpisovanie už prebieha

--- a/src/main/resources/digital/slovensko/autogram/ui/gui/language/l10n_en.properties
+++ b/src/main/resources/digital/slovensko/autogram/ui/gui/language/l10n_en.properties
@@ -50,6 +50,10 @@ error.BatchCanceledException.heading=Batch canceled
 error.BatchCanceledException.subheading=
 error.BatchCanceledException.description=Batch canceled
 
+error.BulkSigningDisabledException.heading=Bulk signing is disabled
+error.BulkSigningDisabledException.subheading=Bulk signing is not allowed
+error.BulkSigningDisabledException.description=Bulk signing is disabled in settings. Enable it and try again.
+
 error.BatchConflictException.heading=Another batch signing is already in progress
 error.BatchConflictException.subheading=Only one batch signing can be performed at a time
 error.BatchConflictException.description=Another batch signing is already in progress

--- a/src/test/java/digital/slovensko/autogram/AutogramTests.java
+++ b/src/test/java/digital/slovensko/autogram/AutogramTests.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.sun.net.httpserver.HttpExchange;
 import digital.slovensko.autogram.core.*;
 import digital.slovensko.autogram.core.errors.AutogramException;
+import digital.slovensko.autogram.core.errors.BulkSigningDisabledException;
 import digital.slovensko.autogram.core.errors.CertificatesReadingConsentRejectedException;
 import digital.slovensko.autogram.core.errors.NoDriversDetectedException;
 import digital.slovensko.autogram.core.errors.UnknownEformException;
@@ -146,6 +147,16 @@ class AutogramTests {
                 key -> autogram.sign(SigningJob.buildFromFile(file, responder, false, SignatureLevel.XAdES_BASELINE_B, false, null, false), key));
 
         verify(responder).onDocumentSigned(any());
+    }
+
+    @Test
+    void testBatchStartThrowsWhenBulkSigningDisabled() {
+        var settings = new TestSettings();
+        var newUI = new FakeUI();
+        var autogram = new Autogram(newUI, settings);
+
+        var responder = mock(BatchResponder.class);
+        Assertions.assertThrows(BulkSigningDisabledException.class, () -> autogram.batchStart(1, responder));
     }
 
     @Test


### PR DESCRIPTION
Adds validation to enforce the bulk signing configuration setting. When `batchStart()` is called, the application now checks if bulk signing is enabled via `settings.isBulkEnabled()`. If disabled, it throws a `BulkSigningDisabledException` to prevent batch operations.

Changes:
- New `BulkSigningDisabledException` exception class
- Configuration check in `Autogram.batchStart()` method
- Localized error messages for Slovak and English
- Unit tests for the validation behavior

Fixes #654