### PR TITLE
feat(cli, macOS): add headless signing and Finder Quick Action

### DIFF
--- a/README-SK.md
+++ b/README-SK.md
@@ -21,6 +21,14 @@ Autogram je možné spúšťať aj z príkazového riadku (CLI mód). Detailné 
 
 Pre skriptovaný výber certifikátu, zadanie PIN-u cez štandardný vstup, PAdES Baseline T a návratové kódy pozri [CLI podpisovanie bez interakcie](docs/cli-headless-signing.md).
 
+## macOS Finder Quick Action
+
+Súčasťou repozitára je aj Automator Quick Action na podpisovanie jedného alebo viacerých označených PDF súborov vo Finderi cez Autogram CLI. Ide o integráciu do Finderu, nie o workflow pre macOS Shortcuts. Výber úložiska certifikátu, certifikátu a zadanie PIN-u prebieha cez macOS dialógy, samotné podpisovanie prebieha bez otvorenia grafického rozhrania Autogramu alebo Terminálu.
+
+Integrácia vyžaduje macOS s Finderom a Automatorom, kompatibilný token alebo kartu s PKCS#11 ovládačom, PIN a sieťové pripojenie ku kvalifikovanej službe časových pečiatok pri PAdES Baseline T. Na Apple Silicon môže byť pri Intel-only PKCS#11 ovládači potrebná Rosetta a Intel build Autogramu.
+
+Pozri [macOS CLI a Finder Quick Action](docs/macos-cli-automation.md), kde je návod na inštaláciu, hromadné podpisovanie, konfiguráciu a riešenie problémov.
+
 ### Štýlovanie
 
 Aplikácia momentálne podporuje len jeden štýl - štátny IDSK dizajn. Ďalšie štýly sú plánované. Štýlovanie sa však už teraz deje výhradne cez kaskádové štýly, viď [idsk.css](https://github.com/slovensko-digital/autogram/blob/main/src/main/resources/digital/slovensko/autogram/ui/gui/idsk.css)

--- a/README-SK.md
+++ b/README-SK.md
@@ -19,6 +19,8 @@ Vyvolať spustenie programu je možné priamo z webového prehliadača otvorení
 
 Autogram je možné spúšťať aj z príkazového riadku (CLI mód). Detailné informácie o prepínačoch sú popísané v nápovede po spustení `autogram --help`, resp. `autogram-cli --help` na Windows.
 
+Pre skriptovaný výber certifikátu, zadanie PIN-u cez štandardný vstup, PAdES Baseline T a návratové kódy pozri [CLI podpisovanie bez interakcie](docs/cli-headless-signing.md).
+
 ### Štýlovanie
 
 Aplikácia momentálne podporuje len jeden štýl - štátny IDSK dizajn. Ďalšie štýly sú plánované. Štýlovanie sa však už teraz deje výhradne cez kaskádové štýly, viď [idsk.css](https://github.com/slovensko-digital/autogram/blob/main/src/main/resources/digital/slovensko/autogram/ui/gui/idsk.css)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Autogram can also be run from the command line (CLI mode). Detailed information 
 
 For scripted certificate selection, PIN input from standard input, PAdES Baseline T, and exit status handling, see [Headless CLI signing](docs/cli-headless-signing.md).
 
+## macOS Finder Quick Action
+
+The repository also includes an Automator Quick Action for signing one or more selected PDF files from Finder through the Autogram CLI. It is a Finder integration, not a macOS Shortcuts workflow. Certificate store selection, certificate selection, and PIN entry use macOS dialogs, while the signing operation runs without opening the Autogram GUI or a Terminal window.
+
+The integration requires macOS with Finder and Automator, a compatible token or card with its PKCS#11 driver, the PIN, and network access to a qualified timestamp service for PAdES Baseline T. Apple Silicon Macs may also need Rosetta and an Intel Autogram build when the installed PKCS#11 driver is Intel-only.
+
+See [macOS CLI and Finder Quick Action](docs/macos-cli-automation.md) for installation, batch signing, configuration, and troubleshooting.
+
 ### Styling
 
 The application currently supports only one style - the state IDSK design. Additional styles are planned. However, styling already happens exclusively through cascading style sheets, see [idsk.css](https://github.com/slovensko-digital/autogram/blob/main/src/main/resources/digital/slovensko/autogram/ui/gui/idsk.css)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ You can trigger the application to run directly from a web browser by opening an
 
 Autogram can also be run from the command line (CLI mode). Detailed information about the switches is described in the help after running `autogram --help`, or `autogram-cli --help` on Windows.
 
+For scripted certificate selection, PIN input from standard input, PAdES Baseline T, and exit status handling, see [Headless CLI signing](docs/cli-headless-signing.md).
+
 ### Styling
 
 The application currently supports only one style - the state IDSK design. Additional styles are planned. However, styling already happens exclusively through cascading style sheets, see [idsk.css](https://github.com/slovensko-digital/autogram/blob/main/src/main/resources/digital/slovensko/autogram/ui/gui/idsk.css)

--- a/docs/cli-headless-signing.md
+++ b/docs/cli-headless-signing.md
@@ -1,0 +1,52 @@
+# Headless CLI signing
+
+Autogram CLI can be used by scripts and desktop integrations without an interactive certificate or PIN prompt. The same options also support batch signing from a directory.
+
+## Select a certificate
+
+List certificates exposed by the selected driver:
+
+```sh
+printf '%s\n' "$PIN" | autogram --cli \
+  --driver secure_store \
+  --list-keys \
+  --pin-stdin
+```
+
+The machine-readable records have the form `AUTOGRAM_KEY<TAB>serial<TAB>common-name`. Use either the certificate serial number or common name with `--key`:
+
+```sh
+printf '%s\n' "$PIN" | autogram --cli \
+  --driver secure_store \
+  --key "123456789" \
+  --pin-stdin \
+  --source "$HOME/Documents/input.pdf" \
+  --target "$HOME/Documents/input_signed.pdf"
+```
+
+The PIN is read from standard input only when `--pin-stdin` is present. Do not place a real PIN in shell history, source code, or a committed configuration file. Prefer an operating-system secret store or a protected input pipe.
+
+## PAdES Baseline T
+
+For a timestamped PDF signature, use `PAdES_BASELINE_T` and provide one or more TSA endpoints:
+
+```sh
+autogram --cli \
+  --driver secure_store \
+  --pdf-level PAdES_BASELINE_T \
+  --tsa-server "http://timestamp.sectigo.com/qualified" \
+  --source "$HOME/Documents/input.pdf" \
+  --target "$HOME/Documents/input_signed.pdf"
+```
+
+The signature level must be routed to the PAdES builder for PDF input. Whether a TSA service is legally qualified depends on the service and its status in the applicable trusted list. Verify the service before relying on the signature for a regulated workflow.
+
+## Exit status
+
+The CLI exits with status `0` after successful processing and a non-zero status when argument parsing, driver discovery, certificate selection, PIN access, or signing fails. This allows Finder actions and other wrappers to report failures without relying on terminal text.
+
+## Security notes
+
+- Keep PIN input outside command-line arguments because process arguments can be observable.
+- Do not commit token details, private keys, personal certificate names, or client documents.
+- Treat the signed output as a new file. The source document is not overwritten unless `--force` is explicitly used.

--- a/docs/macos-cli-automation.md
+++ b/docs/macos-cli-automation.md
@@ -1,0 +1,108 @@
+# macOS CLI and Finder Quick Action
+
+Autogram can be run in CLI mode on macOS and used from Finder through an Automator Quick Action. The Quick Action is a Finder integration, not a macOS Shortcuts workflow. It uses macOS dialogs for certificate store selection, certificate selection, and PIN entry, then runs the signing operation through the Autogram CLI without opening the Autogram GUI or a Terminal window.
+
+## Requirements
+
+- macOS with Finder and Automator.
+- An Autogram application with the headless CLI options described in [Headless CLI signing](cli-headless-signing.md).
+- A compatible signing token or card, its PKCS#11 driver, and the PIN.
+- Network access to the configured qualified timestamp service when PAdES Baseline T is required.
+- Rosetta and an Intel Autogram build on Apple Silicon when the installed PKCS#11 driver is Intel-only.
+
+The scripts do not install Autogram, a token driver, Rosetta, or a timestamp service.
+
+## Install the scripts
+
+From the repository root:
+
+```bash
+chmod +x scripts/macos-automation/*.sh
+```
+
+The scripts look for the application in these locations:
+
+- `/Applications/Autogram.app/Contents/MacOS/AutogramApp`
+- `$HOME/Applications/Autogram.app/Contents/MacOS/AutogramApp`
+- `target/app-image/Autogram.app/Contents/MacOS/AutogramApp` for a local build
+
+Set `AUTOGRAM_BIN` when the application is installed elsewhere. For an Intel-only PKCS#11 driver on Apple Silicon, set `AUTOGRAM_INTEL_BIN` to an Intel Autogram executable or install an Intel Autogram application in one of the documented locations.
+
+## Create the Finder Quick Action
+
+1. Open **Automator** and create a new **Quick Action**. Do not create a macOS Shortcuts workflow for this integration.
+2. Set **Workflow receives current** to `files or folders` and **In** to `Finder`.
+3. Add the **Run Shell Script** action.
+4. Set **Shell** to `/bin/bash` and **Pass input** to `as arguments`.
+5. Use this script body, replacing the repository path with the local clone path:
+
+```bash
+REPO_DIR="/path/to/autogram"
+"$REPO_DIR/scripts/macos-automation/autogram-quick-action.sh" "$@"
+```
+
+6. Save the Quick Action as `Sign PDFs Autogram`.
+
+Select one or more PDF files in Finder, right-click, open **Quick Actions**, and choose `Sign PDFs Autogram`. Only PDF files are processed. The original files are not overwritten. Signed files are saved beside the originals as `<name>_signed.pdf`, with numbered variants when that name already exists.
+
+The Quick Action asks for the certificate store, PIN, and certificate when more than one certificate is available. It signs each selected PDF with PAdES Baseline T and requests a timestamp from the configured qualified TSA.
+
+## Configuration
+
+The following environment variables are supported:
+
+- `AUTOGRAM_BIN`: path to the native Autogram executable.
+- `AUTOGRAM_INTEL_BIN`: path to an Intel Autogram executable for Rosetta execution.
+- `AUTOGRAM_SECURE_STORE_PKCS11_PATH`: override the default I.CA SecureStore PKCS#11 library path.
+- `AUTOGRAM_TSA_SERVER`: override the default qualified TSA URL.
+
+Automator has a restricted environment. If an override is needed, define it in the Quick Action shell script before invoking `autogram-quick-action.sh`, for example:
+
+```bash
+export AUTOGRAM_BIN="/path/to/Autogram.app/Contents/MacOS/AutogramApp"
+export AUTOGRAM_TSA_SERVER="https://timestamp.example.invalid/qualified"
+REPO_DIR="/path/to/autogram"
+"$REPO_DIR/scripts/macos-automation/autogram-quick-action.sh" "$@"
+```
+
+Replace the example TSA URL with a real qualified service and verify its status in the applicable EU Trusted List before relying on it.
+
+## Manual CLI use
+
+```bash
+scripts/macos-automation/autogram-cli-sign.sh \
+  --driver secure_store \
+  --pdf-level PAdES_BASELINE_T \
+  --tsa-server "http://timestamp.sectigo.com/qualified" \
+  "/path/to/file.pdf"
+```
+
+For non-interactive certificate and PIN handling, use the headless options:
+
+```bash
+printf '%s\n' "$PIN_VALUE" | \
+  scripts/macos-automation/autogram-cli-sign.sh \
+    --driver secure_store \
+    --list-keys \
+    --pin-stdin
+```
+
+Do not put a real PIN, private key, client document, or certificate identity in shell history, source files, or the repository.
+
+## Finder selection helper
+
+`autogram-finder-selection.sh` reads the current Finder selection through AppleScript and forwards it to the same Quick Action implementation. It can be used from a launcher such as Alfred or Raycast:
+
+```bash
+REPO_DIR="/path/to/autogram"
+"$REPO_DIR/scripts/macos-automation/autogram-finder-selection.sh"
+```
+
+## Troubleshooting
+
+- If no Autogram executable is found, set `AUTOGRAM_BIN` explicitly.
+- If an Apple Silicon Mac reports an incompatible `x86_64` PKCS#11 library, install Rosetta and use an Intel Autogram build through `AUTOGRAM_INTEL_BIN`.
+- If certificates cannot be loaded, check the token, PKCS#11 driver, PIN, and the selected driver name.
+- If a timestamped PDF is expected, make sure `PAdES_BASELINE_T` is routed to the PDF signing path and that the TSA is reachable.
+- The Quick Action validates the output by checking the PDF header and end marker. This avoids treating an ASiC ZIP with a `.pdf` extension as a successfully signed PDF.
+- Use absolute paths for system tools in Automator scripts. Developer tools such as `rg` may not be available in Automator's restricted `PATH`.

--- a/scripts/macos-automation/autogram-cli-sign.sh
+++ b/scripts/macos-automation/autogram-cli-sign.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Optional overrides:
+#   AUTOGRAM_BIN=/path/to/AutogramApp ./autogram-cli-sign.sh file1.pdf
+#   AUTOGRAM_INTEL_BIN=/path/to/Intel/AutogramApp ./autogram-cli-sign.sh --driver secure_store file1.pdf
+resolve_autogram_bin() {
+  local candidates=(
+    "${AUTOGRAM_BIN:-}"
+    "/Applications/Autogram.app/Contents/MacOS/AutogramApp"
+    "$HOME/Applications/Autogram.app/Contents/MacOS/AutogramApp"
+    "$(cd "$(dirname "$0")/../.." && pwd)/target/app-image/Autogram.app/Contents/MacOS/AutogramApp"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -n "$candidate" && -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+resolve_intel_autogram_bin() {
+  local candidates=(
+    "${AUTOGRAM_INTEL_BIN:-}"
+    "${AUTOGRAM_BIN:-}"
+    "$HOME/Applications/Autogram Intel GUI.app/Contents/MacOS/AutogramApp"
+    "$HOME/Applications/Autogram Intel.app/Contents/MacOS/AutogramApp"
+    "/Applications/Autogram Intel.app/Contents/MacOS/AutogramApp"
+    "$HOME/Applications/Autogram-intel.app/Contents/MacOS/AutogramApp"
+    "/Applications/Autogram-intel.app/Contents/MacOS/AutogramApp"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -n "$candidate" && -x "$candidate" ]] && /usr/bin/lipo -verify_arch x86_64 "$candidate" >/dev/null 2>&1; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+secure_store_driver_path() {
+  printf '%s\n' "${AUTOGRAM_SECURE_STORE_PKCS11_PATH:-/usr/local/lib/pkcs11/libICASecureStorePkcs11.dylib}"
+}
+
+secure_store_requires_intel_autogram() {
+  [[ "$(uname -m)" == "arm64" ]] || return 1
+
+  local driver_path
+  driver_path="$(secure_store_driver_path)"
+  [[ -f "$driver_path" ]] || return 1
+
+  ! /usr/bin/lipo -verify_arch arm64 "$driver_path" >/dev/null 2>&1
+}
+
+should_use_intel_autogram() {
+  local requested_driver="${1:-}"
+
+  [[ "$(uname -m)" == "arm64" ]] || return 1
+
+  if [[ "$requested_driver" == "secure_store" ]]; then
+    secure_store_requires_intel_autogram
+    return $?
+  fi
+
+  [[ -z "$requested_driver" ]] && secure_store_requires_intel_autogram
+}
+
+run_autogram() {
+  local app_bin="$1"
+  shift
+
+  if [[ "$(uname -m)" == "arm64" ]] && /usr/bin/lipo -verify_arch x86_64 "$app_bin" >/dev/null 2>&1 \
+    && ! /usr/bin/lipo -verify_arch arm64 "$app_bin" >/dev/null 2>&1; then
+    echo "Using Intel Autogram through Rosetta: $app_bin" >&2
+    /usr/bin/arch -x86_64 "$app_bin" "$@"
+    return
+  fi
+
+  "$app_bin" "$@"
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  autogram-cli-sign.sh [options] <file-or-dir> [...]
+
+Examples:
+  autogram-cli-sign.sh "/path/to/sample.pdf"
+  autogram-cli-sign.sh --driver eid --pdfa "/path/to/invoice.pdf"
+
+Notes:
+  - Signed outputs are created by Autogram CLI defaults (e.g. *_signed).
+  - Use --key and --pin-stdin for non-interactive signing.
+  - On Apple Silicon, Intel-only I.CA SecureStore needs an Intel Autogram build through Rosetta.
+  - Common forwarded options include:
+      --driver, --key, --target, --pdf-level, --slot-id, --keystore, --tsa-server, --pkcs11-driver-path
+      --pin-stdin, --list-keys, --pdfa, --plain-xml, --en319132, --force, --parents
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+declare -a common_opts=()
+declare -a sources=()
+requested_driver=""
+list_keys_requested=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --driver|--key|--target|--pdf-level|--slot-id|--keystore|--tsa-server|--pkcs11-driver-path)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for option: $1"
+        exit 1
+      fi
+      common_opts+=("$1" "${2:-}")
+      if [[ "$1" == "--driver" ]]; then
+        requested_driver="${2:-}"
+      fi
+      shift 2
+      ;;
+    --pin-stdin|--list-keys|--pdfa|--plain-xml|--en319132|--force|--parents)
+      common_opts+=("$1")
+      [[ "$1" == "--list-keys" ]] && list_keys_requested=1
+      shift
+      ;;
+    -*)
+      echo "Unsupported option: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      sources+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#sources[@]} -eq 0 && "$list_keys_requested" -eq 0 ]]; then
+  echo "No source file or directory provided."
+  usage
+  exit 1
+fi
+
+AUTOGRAM_APP_BIN="$(resolve_autogram_bin || true)"
+if should_use_intel_autogram "$requested_driver"; then
+  INTEL_AUTOGRAM_APP_BIN="$(resolve_intel_autogram_bin || true)"
+  if [[ -z "$INTEL_AUTOGRAM_APP_BIN" ]]; then
+    echo "Intel Autogram is required for the installed I.CA SecureStore driver."
+    echo "The driver is x86_64-only, while this Mac runs on Apple Silicon."
+    echo "Install the official Intel Autogram package or set AUTOGRAM_INTEL_BIN explicitly."
+    echo "Expected Intel app: \$HOME/Applications/Autogram Intel GUI.app/Contents/MacOS/AutogramApp"
+    exit 1
+  fi
+  AUTOGRAM_APP_BIN="$INTEL_AUTOGRAM_APP_BIN"
+fi
+
+if [[ -z "$AUTOGRAM_APP_BIN" ]]; then
+  echo "Autogram executable not found."
+  echo "Expected one of:"
+  echo "  /Applications/Autogram.app/Contents/MacOS/AutogramApp"
+  echo "  \$HOME/Applications/Autogram.app/Contents/MacOS/AutogramApp"
+  echo "  <repo>/target/app-image/Autogram.app/Contents/MacOS/AutogramApp"
+  echo "Or set AUTOGRAM_BIN explicitly."
+  exit 1
+fi
+
+if [[ "$list_keys_requested" -eq 1 ]]; then
+  run_autogram "$AUTOGRAM_APP_BIN" --cli "${common_opts[@]}"
+else
+  for src in "${sources[@]}"; do
+    echo "Signing: $src"
+    if [[ ${#common_opts[@]} -gt 0 ]]; then
+      run_autogram "$AUTOGRAM_APP_BIN" --cli -s "$src" "${common_opts[@]}"
+    else
+      run_autogram "$AUTOGRAM_APP_BIN" --cli -s "$src"
+    fi
+  done
+fi
+
+echo "Done."

--- a/scripts/macos-automation/autogram-finder-selection.sh
+++ b/scripts/macos-automation/autogram-finder-selection.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+QUICK_ACTION_SCRIPT="$SCRIPT_DIR/autogram-quick-action.sh"
+
+if [[ ! -x "$QUICK_ACTION_SCRIPT" ]]; then
+  echo "Quick action launcher is missing or not executable: $QUICK_ACTION_SCRIPT"
+  exit 1
+fi
+
+finder_selection_text="$(/usr/bin/osascript <<'OSA'
+tell application "Finder"
+  if (count of selection) is 0 then
+    return ""
+  end if
+
+  set outText to ""
+  repeat with it in selection
+    set outText to outText & POSIX path of (it as alias) & linefeed
+  end repeat
+  return outText
+end tell
+OSA
+)"
+
+declare -a finder_selection=()
+while IFS= read -r selected_path; do
+  [[ -n "$selected_path" ]] && finder_selection+=("$selected_path")
+done <<< "$finder_selection_text"
+
+if [[ ${#finder_selection[@]} -eq 0 || -z "${finder_selection[0]:-}" ]]; then
+  echo "No selected files/folders found in Finder."
+  exit 0
+fi
+
+"$QUICK_ACTION_SCRIPT" "${finder_selection[@]}"

--- a/scripts/macos-automation/autogram-quick-action.sh
+++ b/scripts/macos-automation/autogram-quick-action.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLI_SCRIPT="$SCRIPT_DIR/autogram-cli-sign.sh"
+QUALIFIED_TSA_URL="${AUTOGRAM_TSA_SERVER:-http://timestamp.sectigo.com/qualified}"
+
+show_alert() {
+  local title="$1"
+  local message="$2"
+
+  /usr/bin/osascript - "$title" "$message" <<'OSA'
+on run argv
+  display alert (item 1 of argv) message (item 2 of argv) as warning
+end run
+OSA
+}
+
+choose_driver() {
+  /usr/bin/osascript <<'OSA'
+set driverChoices to {"I.CA SecureStore", "Občiansky preukaz (eID klient)"}
+set selectedDriver to choose from list driverChoices ¬
+  with title "Autogram: CLI podpis PDF" ¬
+  with prompt "Vyberte úložisko podpisového certifikátu." ¬
+  default items {"I.CA SecureStore"} ¬
+  OK button name "Pokračovať" ¬
+  cancel button name "Zrušiť" ¬
+  without multiple selections allowed
+
+if selectedDriver is false then
+  return "CANCELLED"
+end if
+
+return item 1 of selectedDriver
+OSA
+}
+
+choose_key_label() {
+  /usr/bin/osascript - "$@" <<'OSA'
+on run argv
+  set selectedKey to choose from list argv ¬
+    with title "Autogram: podpisový certifikát" ¬
+    with prompt "Vyberte certifikát, ktorým sa má PDF podpísať." ¬
+    OK button name "Vybrať" ¬
+    cancel button name "Zrušiť" ¬
+    without multiple selections allowed
+
+  if selectedKey is false then
+    return "CANCELLED"
+  end if
+
+  return item 1 of selectedKey
+end run
+OSA
+}
+
+ask_pin() {
+  /usr/bin/osascript <<'OSA'
+try
+  set pinDialog to display dialog "Zadajte podpisový PIN alebo heslo k certifikátu." ¬
+    with title "Autogram: podpisový PIN" ¬
+    default answer "" ¬
+    with hidden answer ¬
+    buttons {"Zrušiť", "Podpísať"} ¬
+    default button "Podpísať" ¬
+    cancel button "Zrušiť"
+  return text returned of pinDialog
+on error number -128
+  return "CANCELLED"
+end try
+OSA
+}
+
+collect_pdfs() {
+  local item
+
+  for item in "$@"; do
+    if [[ -f "$item" ]]; then
+      case "${item##*.}" in
+        [pP][dD][fF]) printf '%s\0' "$item" ;;
+      esac
+    elif [[ -d "$item" ]]; then
+        /usr/bin/find "$item" -type f -iname '*.pdf' -print0
+    fi
+  done
+}
+
+next_signed_path() {
+  local source="$1"
+  local stem="${source%.*}"
+  local candidate="${stem}_signed.pdf"
+  local suffix=1
+
+  while [[ -e "$candidate" ]]; do
+    candidate="${stem}_signed ($suffix).pdf"
+    suffix=$((suffix + 1))
+  done
+
+  printf '%s\n' "$candidate"
+}
+
+is_valid_pdf() {
+  local path="$1"
+  [[ -s "$path" ]] || return 1
+  [[ "$(/usr/bin/head -c 5 "$path")" == "%PDF-" ]] || return 1
+  /usr/bin/tail -c 1024 "$path" | /usr/bin/grep -q '%%EOF'
+}
+
+cli_error_details() {
+  local log_file="$1"
+  local details
+
+  details="$(/usr/bin/tail -n 12 "$log_file" 2>/dev/null | /usr/bin/tr '\n' ' ' | /usr/bin/cut -c1-800)"
+  if [[ -z "$details" ]]; then
+    details="CLI neposkytlo ďalšie podrobnosti."
+  fi
+
+  printf '%s\n' "$details"
+}
+
+driver_shortname() {
+  case "$1" in
+    "I.CA SecureStore") printf '%s\n' "secure_store" ;;
+    "Občiansky preukaz (eID klient)") printf '%s\n' "eid" ;;
+    *) return 1 ;;
+  esac
+}
+
+if [[ $# -eq 0 ]]; then
+  show_alert "Autogram" "Neboli odovzdané žiadne súbory."
+  exit 0
+fi
+
+declare -a pdfs=()
+while IFS= read -r -d '' pdf; do
+  pdfs+=("$pdf")
+done < <(collect_pdfs "$@")
+
+if [[ ${#pdfs[@]} -eq 0 ]]; then
+  show_alert "Autogram" "Vo výbere sa nenašli žiadne PDF súbory."
+  exit 0
+fi
+
+driver_name="$(choose_driver)"
+if [[ "$driver_name" == "CANCELLED" || -z "$driver_name" ]]; then
+  exit 0
+fi
+
+driver_name_arg="$(driver_shortname "$driver_name" || true)"
+if [[ -z "$driver_name_arg" ]]; then
+  show_alert "Autogram" "Neznáme úložisko certifikátu: $driver_name"
+  exit 1
+fi
+
+tmp_dir="$(/usr/bin/mktemp -d -t autogram-quick-action)"
+trap '/bin/rm -rf "$tmp_dir"' EXIT
+
+pin="$(ask_pin)"
+if [[ "$pin" == "CANCELLED" ]]; then
+  exit 0
+fi
+
+key_output="$tmp_dir/keys.tsv"
+key_error="$tmp_dir/keys.error"
+set +e
+printf '%s\n' "$pin" | "$CLI_SCRIPT" \
+    --driver "$driver_name_arg" \
+    --list-keys \
+    --pin-stdin > "$key_output" 2> "$key_error"
+key_status=$?
+set -e
+
+if [[ "$key_status" -ne 0 ]] && ! /usr/bin/grep -q $'^AUTOGRAM_KEY\t' "$key_output"; then
+  key_details="$(cli_error_details "$key_error")"
+  key_message="$(printf '%s\n\n%s' \
+    'Nepodarilo sa načítať podpisové certifikáty. Skontrolujte pripojené úložisko a PIN.' \
+    "$key_details")"
+  show_alert "Autogram" "$key_message"
+  exit 0
+fi
+
+declare -a key_selectors=()
+declare -a key_labels=()
+while IFS=$'\t' read -r record_type selector label; do
+  [[ "$record_type" == "AUTOGRAM_KEY" ]] || continue
+  [[ -n "$selector" ]] || continue
+  key_selectors+=("$selector")
+  key_labels+=("$label [$selector]")
+done < "$key_output"
+
+if [[ ${#key_selectors[@]} -eq 0 ]]; then
+  show_alert "Autogram" "V zvolenom úložisku sa nenašiel žiadny podpisový certifikát."
+  exit 1
+fi
+
+if [[ ${#key_selectors[@]} -eq 1 ]]; then
+  key_selector="${key_selectors[0]}"
+else
+  selected_label="$(choose_key_label "${key_labels[@]}")"
+  if [[ "$selected_label" == "CANCELLED" || -z "$selected_label" ]]; then
+    exit 0
+  fi
+
+  key_selector=""
+  for index in "${!key_labels[@]}"; do
+    if [[ "${key_labels[$index]}" == "$selected_label" ]]; then
+      key_selector="${key_selectors[$index]}"
+      break
+    fi
+  done
+
+  if [[ -z "$key_selector" ]]; then
+    show_alert "Autogram" "Nepodarilo sa vybrať podpisový certifikát."
+    exit 1
+  fi
+fi
+
+for index in "${!pdfs[@]}"; do
+  log_file="$tmp_dir/sign-$index.log"
+  target_path="$(next_signed_path "${pdfs[$index]}")"
+  set +e
+  printf '%s\n' "$pin" | "$CLI_SCRIPT" \
+      --driver "$driver_name_arg" \
+      --key "$key_selector" \
+      --pin-stdin \
+      --pdf-level PAdES_BASELINE_T \
+      --tsa-server "$QUALIFIED_TSA_URL" \
+      --target "$target_path" \
+      "${pdfs[$index]}" > "$log_file" 2>&1
+  set -e
+
+  if ! is_valid_pdf "$target_path"; then
+    sign_details="$(cli_error_details "$log_file")"
+    sign_message="$(printf 'Podpisovanie zlyhalo pri súbore: %s\n\n%s' \
+      "${pdfs[$index]}" "$sign_details")"
+    show_alert "Autogram" "$sign_message"
+    exit 0
+  fi
+done
+
+success_message="$(printf 'Podpísaných PDF: %s\nPoužitý podpis: PAdES Baseline T\nKvalifikovaná časová pečiatka: Sectigo qualified TSA' "${#pdfs[@]}")"
+show_alert "Autogram" "$success_message"

--- a/src/main/java/digital/slovensko/autogram/core/AppStarter.java
+++ b/src/main/java/digital/slovensko/autogram/core/AppStarter.java
@@ -21,9 +21,12 @@ public class AppStarter {
         addOption(null, "pdfa", false, "Check PDF/A compliance before signing.").
         addOption(null, "parents", false, "Create all parent directories for target if needed.").
         addOption("d", "driver", true, "PCKS driver name for signing. Supported values: eid, cz_eid, secure_store, monet, gemalto, keystore, custom_pkcs11 (requires valid path within pkcs11-driver-path option).").
+        addOption(null, "key", true, "Certificate serial number or common name to use without an interactive key prompt.").
+        addOption(null, "pin-stdin", false, "Read the signing PIN or password from standard input without an interactive prompt.").
+        addOption(null, "list-keys", false, "List available signing certificates and exit.").
         addOption(null, "keystore", true, "Absolute path to a keystore file that can be used for signing.").
         addOption(null, "slot-id", true, "Slot ID for PKCS11 driver. If not specified, first available slot is used.").
-        addOption(null, "pdf-level", true, "PDF signature level. Supported values: PAdES_BASELINE_B (default), XAdES_BASELINE_B, CAdES_BASELINE_B.").
+        addOption(null, "pdf-level", true, "PDF signature level. Supported values include PAdES_BASELINE_B and PAdES_BASELINE_T.").
         addOption(null, "en319132", false, "Sign according to EN 319 132 or EN 319 122.").
         addOption(null, "tsa-server", true, "Url of TimeStamp Authority server that should be used for timestamping in signature level BASELINE_T. If provided, BASELINE_T signatures are made.").
         addOption(null, "plain-xml", false, "Enable signing plain (non-slovak-eform) XML files.").
@@ -39,7 +42,7 @@ public class AppStarter {
             } else if (cmd.hasOption("u")) {
                 printUsage();
             } else if (cmd.hasOption("c")) {
-                CliApp.start(cmd);
+                System.exit(CliApp.start(cmd));
             } else {
                 Application.launch(GUIApp.class, args);
             }

--- a/src/main/java/digital/slovensko/autogram/core/Autogram.java
+++ b/src/main/java/digital/slovensko/autogram/core/Autogram.java
@@ -20,6 +20,7 @@ import digital.slovensko.autogram.util.PDFUtils;
 import eu.europa.esig.dss.model.DSSException;
 import eu.europa.esig.dss.pdfa.PDFAStructureValidator;
 import eu.europa.esig.dss.spi.x509.tsp.TSPSource;
+import eu.europa.esig.dss.token.DSSPrivateKeyEntry;
 
 import java.io.File;
 import java.util.List;
@@ -289,6 +290,11 @@ public class Autogram {
 
     public List<TokenDriver> getAvailableDrivers() {
         return settings.getDriverDetector().getAvailableDrivers();
+    }
+
+    public List<DSSPrivateKeyEntry> getSigningKeys(TokenDriver driver) {
+        var token = driver.createToken(passwordManager, settings);
+        return token.getKeys();
     }
 
     public boolean isPlainXmlEnabled() {

--- a/src/main/java/digital/slovensko/autogram/core/SigningJob.java
+++ b/src/main/java/digital/slovensko/autogram/core/SigningJob.java
@@ -209,6 +209,7 @@ public class SigningJob {
 
         if (isPDF(document.getMimeType())) switch (signatureType) {
             case PAdES_BASELINE_B:
+            case PAdES_BASELINE_T:
                 return SigningParameters.buildForPDF(document, checkPDFACompliance, isEn319132, tspSource);
             case XAdES_BASELINE_B:
                 return SigningParameters.buildForASiCWithXAdES(document, checkPDFACompliance, isEn319132, tspSource, plainXmlEnabled);

--- a/src/main/java/digital/slovensko/autogram/core/UserSettings.java
+++ b/src/main/java/digital/slovensko/autogram/core/UserSettings.java
@@ -226,7 +226,8 @@ public class UserSettings implements PasswordManagerSettings, SignatureTokenSett
     }
 
     public boolean shouldSignPDFAsPades() {
-        return signatureLevel == SignatureLevel.PAdES_BASELINE_B;
+        return signatureLevel == SignatureLevel.PAdES_BASELINE_B
+                || signatureLevel == SignatureLevel.PAdES_BASELINE_T;
     }
 
     public void setSignatureLevel(SignatureLevel signatureLevel) {

--- a/src/main/java/digital/slovensko/autogram/ui/cli/CliApp.java
+++ b/src/main/java/digital/slovensko/autogram/ui/cli/CliApp.java
@@ -7,18 +7,25 @@ import digital.slovensko.autogram.core.errors.AutogramException;
 import digital.slovensko.autogram.core.errors.SourceDoesNotExistException;
 import digital.slovensko.autogram.core.errors.SourceNotDefinedException;
 import digital.slovensko.autogram.ui.SaveFileResponder;
+import eu.europa.esig.dss.model.DSSException;
 import org.apache.commons.cli.CommandLine;
 
 import java.io.File;
 import java.util.Arrays;
 
 public class CliApp {
-    public static void start(CommandLine cmd) {
+    public static int start(CommandLine cmd) {
         Autogram autogram = null;
         try {
             var settings = CliSettings.fromCmd(cmd);
             var ui = new CliUI(settings);
             autogram = new Autogram(ui, settings);
+
+            if (settings.isListKeys()) {
+                var driver = ui.pickTokenDriver(autogram.getAvailableDrivers());
+                ui.printSigningKeys(autogram.getSigningKeys(driver));
+                return 0;
+            }
 
             if (settings.getSource() == null)
                 throw new SourceNotDefinedException();
@@ -47,13 +54,26 @@ public class CliApp {
 
             ui.setJobsCount(jobs.size());
             jobs.forEach(autogram::sign);
+            return 0;
 
         } catch (AutogramException e) {
             System.err.println(CliUI.parseError(e));
-
+            return 1;
+        } catch (DSSException e) {
+            return reportFailure(AutogramException.createFromDSSException(e));
+        } catch (Exception e) {
+            return reportFailure(e);
         } finally {
             if (autogram != null)
                 autogram.shutdown();
         }
+    }
+
+    static int reportFailure(Exception e) {
+        if (e instanceof AutogramException autogramException)
+            System.err.println(CliUI.parseError(autogramException));
+        else
+            e.printStackTrace(System.err);
+        return 1;
     }
 }

--- a/src/main/java/digital/slovensko/autogram/ui/cli/CliKeySelector.java
+++ b/src/main/java/digital/slovensko/autogram/ui/cli/CliKeySelector.java
@@ -1,0 +1,31 @@
+package digital.slovensko.autogram.ui.cli;
+
+import digital.slovensko.autogram.util.DSSUtils;
+import eu.europa.esig.dss.token.DSSPrivateKeyEntry;
+
+public final class CliKeySelector {
+    private CliKeySelector() {
+    }
+
+    public static boolean matches(DSSPrivateKeyEntry key, String selector) {
+        var certificate = key.getCertificate();
+        return matches(certificate.getSerialNumber().toString(),
+                DSSUtils.parseCN(certificate.getSubject().getRFC2253()), selector);
+    }
+
+    public static boolean matches(String serial, String commonName, String selector) {
+        if (selector == null || selector.isBlank())
+            return false;
+
+        var normalizedSelector = selector.trim();
+        return normalizedSelector.equals(serial) || normalizedSelector.equals(commonName);
+    }
+
+    public static String serial(DSSPrivateKeyEntry key) {
+        return key.getCertificate().getSerialNumber().toString();
+    }
+
+    public static String commonName(DSSPrivateKeyEntry key) {
+        return DSSUtils.parseCN(key.getCertificate().getSubject().getRFC2253());
+    }
+}

--- a/src/main/java/digital/slovensko/autogram/ui/cli/CliSettings.java
+++ b/src/main/java/digital/slovensko/autogram/ui/cli/CliSettings.java
@@ -16,6 +16,9 @@ public class CliSettings extends UserSettings {
     private File source;
     private boolean isForce;
     private boolean shouldMakeParentDirectories;
+    private String keySelector;
+    private boolean pinFromStdin;
+    private boolean listKeys;
 
     public static CliSettings fromCmd(CommandLine cmd) {
         var settings = new CliSettings();
@@ -23,6 +26,9 @@ public class CliSettings extends UserSettings {
         settings.setSource(getValidSource(cmd.getOptionValue("s")));
         settings.setTarget(cmd.getOptionValue("t"));
         settings.setDriver(cmd.getOptionValue("d"));
+        settings.setKeySelector(cmd.getOptionValue("key"));
+        settings.setPinFromStdin(cmd.hasOption("pin-stdin"));
+        settings.setListKeys(cmd.hasOption("list-keys"));
         settings.setCustomKeystorePath(cmd.getOptionValue("keystore", ""));
         settings.setDriverSlotIndex("default", getValidSlotIndex(cmd.getOptionValue("slot-id")));
         settings.setForce(cmd.hasOption("f"));
@@ -74,6 +80,30 @@ public class CliSettings extends UserSettings {
 
     public boolean shouldMakeParentDirectories() {
         return shouldMakeParentDirectories;
+    }
+
+    public String getKeySelector() {
+        return keySelector;
+    }
+
+    private void setKeySelector(String value) {
+        keySelector = value;
+    }
+
+    public boolean isPinFromStdin() {
+        return pinFromStdin;
+    }
+
+    private void setPinFromStdin(boolean value) {
+        pinFromStdin = value;
+    }
+
+    public boolean isListKeys() {
+        return listKeys;
+    }
+
+    private void setListKeys(boolean value) {
+        listKeys = value;
     }
 
     private static File getValidSource(String sourcePath) throws SourceDoesNotExistException {

--- a/src/main/java/digital/slovensko/autogram/ui/cli/CliUI.java
+++ b/src/main/java/digital/slovensko/autogram/ui/cli/CliUI.java
@@ -39,7 +39,10 @@ import digital.slovensko.autogram.ui.UI;
 import digital.slovensko.autogram.ui.gui.IgnorableException;
 import eu.europa.esig.dss.token.DSSPrivateKeyEntry;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -51,6 +54,8 @@ public class CliUI implements UI {
     SigningKey activeKey;
     int nJobsSigned = 1;
     int nJobsTotal = 0;
+    private final BufferedReader stdin = new BufferedReader(new InputStreamReader(System.in));
+    private char[] stdinSecret;
 
     public CliUI(CliSettings settings) {
         this.settings = settings;
@@ -91,20 +96,26 @@ public class CliUI implements UI {
 
     @Override
     public void pickTokenDriverAndThen(List<TokenDriver> drivers, Consumer<TokenDriver> callback, Runnable onCancel) {
-        TokenDriver pickedDriver;
+        callback.accept(pickTokenDriver(drivers));
+    }
+
+    public TokenDriver pickTokenDriver(List<TokenDriver> drivers) {
         if (drivers.isEmpty()) {
             showError(new NoDriversDetectedException());
-            return;
+            throw new NoDriversDetectedException();
 
         } else if (drivers.size() == 1) {
-            pickedDriver = drivers.get(0);
+            return drivers.get(0);
 
         } else if (settings.getDefaultDriver() != null) {
-            var driver = drivers.stream().filter(d -> d.getShortname().equals(settings.getDefaultDriver())).findFirst();
+            var driver = drivers.stream()
+                    .filter(d -> d.getShortname().equals(settings.getDefaultDriver())
+                            || d.getName().equals(settings.getDefaultDriver()))
+                    .findFirst();
             if (driver.isEmpty())
                 throw new NoDriversDetectedException();
 
-            pickedDriver = driver.get();
+            return driver.get();
 
         } else {
             var i = new AtomicInteger(1);
@@ -114,15 +125,26 @@ public class CliUI implements UI {
                 System.out.println(driver.getName());
                 i.addAndGet(1);
             });
-            pickedDriver = drivers.get(CliUtils.readInteger() - 1);
+            return drivers.get(CliUtils.readInteger() - 1);
         }
-        callback.accept(pickedDriver);
     }
 
     @Override
     public void pickKeyAndThen(List<DSSPrivateKeyEntry> keys, TokenDriver driver, Consumer<DSSPrivateKeyEntry> callback) {
         if (keys.isEmpty()) {
             showError(new NoKeysDetectedException(driver.getNoKeysHelperText()));
+            return;
+        }
+
+        if (settings.getKeySelector() != null) {
+            var matchingKeys = keys.stream()
+                    .filter(key -> CliKeySelector.matches(key, settings.getKeySelector()))
+                    .toList();
+            if (matchingKeys.size() != 1) {
+                showError(new NoKeysDetectedException(driver.getNoKeysHelperText()));
+                return;
+            }
+            callback.accept(matchingKeys.get(0));
             return;
         }
 
@@ -143,6 +165,13 @@ public class CliUI implements UI {
 
         var pickedKey = keys.get(CliUtils.readInteger() - 1);
         callback.accept(pickedKey);
+    }
+
+    public void printSigningKeys(List<DSSPrivateKeyEntry> keys) {
+        for (var key : keys) {
+            System.out.println("AUTOGRAM_KEY\t" + CliKeySelector.serial(key) + "\t"
+                    + CliKeySelector.commonName(key));
+        }
     }
 
     @Override
@@ -293,11 +322,27 @@ public class CliUI implements UI {
 
     @Override
     public char[] getKeystorePassword() {
-        return System.console().readPassword("Enter keystore password (hidden): ");
+        return readSecret("Enter keystore password (hidden): ");
     }
 
     public char[] getContextSpecificPassword() {
-        return System.console().readPassword("Enter key password (hidden): ");
+        return readSecret("Enter key password (hidden): ");
+    }
+
+    private char[] readSecret(String prompt) {
+        if (!settings.isPinFromStdin())
+            return System.console().readPassword(prompt);
+
+        if (stdinSecret != null)
+            return stdinSecret.clone();
+
+        try {
+            var line = stdin.readLine();
+            stdinSecret = line == null ? null : line.toCharArray();
+            return stdinSecret == null ? null : stdinSecret.clone();
+        } catch (IOException e) {
+            return null;
+        }
     }
 
     @Override

--- a/src/test/java/digital/slovensko/autogram/SigningJobTests.java
+++ b/src/test/java/digital/slovensko/autogram/SigningJobTests.java
@@ -11,6 +11,8 @@ import digital.slovensko.autogram.server.dto.SignRequestBody;
 import digital.slovensko.autogram.server.errors.RequestValidationException;
 import eu.europa.esig.dss.enumerations.ASiCContainerType;
 import eu.europa.esig.dss.enumerations.SignatureLevel;
+import eu.europa.esig.dss.enumerations.SignatureForm;
+import eu.europa.esig.dss.spi.x509.tsp.CompositeTSPSource;
 
 import org.junit.jupiter.api.Test;
 
@@ -69,5 +71,23 @@ public class SigningJobTests {
         } catch (Exception e) {
             fail();
         }
+    }
+
+    @Test
+    void treatsPadesBaselineTAsPdfSigningJob() {
+        var file = new java.io.File("src/test/resources/digital/slovensko/autogram/sample.pdf");
+        var job = SigningJob.buildFromFile(file, null, false, SignatureLevel.PAdES_BASELINE_T,
+                false, new CompositeTSPSource(), true);
+
+        assertEquals(SignatureForm.PAdES, job.getParameters().getSignatureType());
+        assertEquals(SignatureLevel.PAdES_BASELINE_T, job.getParameters().getLevel());
+    }
+
+    @Test
+    void treatsPadesBaselineTAsPadesInUserSettings() {
+        var settings = new UserSettings();
+        settings.setSignatureLevel(SignatureLevel.PAdES_BASELINE_T);
+
+        assertTrue(settings.shouldSignPDFAsPades());
     }
 }

--- a/src/test/java/digital/slovensko/autogram/ui/cli/CliHeadlessSettingsTest.java
+++ b/src/test/java/digital/slovensko/autogram/ui/cli/CliHeadlessSettingsTest.java
@@ -1,0 +1,59 @@
+package digital.slovensko.autogram.ui.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CliHeadlessSettingsTest {
+    @Test
+    void parsesHeadlessCertificateAndPinOptions() throws Exception {
+        var settings = CliSettings.fromCmd(parse(
+                "--driver", "secure_store",
+                "--key", "123456789",
+                "--pin-stdin",
+                "--list-keys"));
+
+        assertEquals("secure_store", settings.getDefaultDriver());
+        assertEquals("123456789", settings.getKeySelector());
+        assertTrue(settings.isPinFromStdin());
+        assertTrue(settings.isListKeys());
+    }
+
+    @Test
+    void matchesCertificateBySerialOrCommonName() {
+        assertTrue(CliKeySelector.matches("123456789", "Test Signer", "123456789"));
+        assertTrue(CliKeySelector.matches("123456789", "Test Signer", "Test Signer"));
+        assertFalse(CliKeySelector.matches("123456789", "Test Signer", "Someone Else"));
+    }
+
+    @Test
+    void reportsUnexpectedCliFailuresWithNonZeroStatus() {
+        var originalError = System.err;
+        var capturedError = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(capturedError));
+        try {
+            assertEquals(1, CliApp.reportFailure(new IllegalStateException("test failure")));
+        } finally {
+            System.setErr(originalError);
+        }
+        assertTrue(capturedError.toString(StandardCharsets.UTF_8).contains("test failure"));
+    }
+
+    private static CommandLine parse(String... args) throws Exception {
+        var options = new Options()
+                .addOption("d", "driver", true, "")
+                .addOption(null, "key", true, "")
+                .addOption(null, "pin-stdin", false, "")
+                .addOption(null, "list-keys", false, "");
+        return new DefaultParser().parse(options, args);
+    }
+}


### PR DESCRIPTION
## Summary

Extend the CLI signing work with a macOS Finder integration that keeps the signing operation headless and scriptable.

## Included

- `--list-keys`, `--key`, and `--pin-stdin` for scripted certificate selection and PIN input.
- PAdES Baseline T routing and qualified timestamp configuration.
- Automator Quick Action for signing one or more selected PDF files from Finder.
- macOS dialogs for driver, certificate, and PIN selection without opening the Autogram GUI or a Terminal window.
- Batch output handling with safe `_signed.pdf` naming and PDF artifact validation.
- Apple Silicon and Intel-only PKCS#11 guidance, including configurable Rosetta execution.
- English and Slovak documentation covering Finder setup, requirements, configuration, and troubleshooting.

## Privacy and portability

- No personal paths, credentials, private keys, client documents, or certificate identities are included.
- Application, PKCS#11 driver, and TSA locations are configurable through environment variables.
- The default Quick Action is macOS-specific, while the underlying CLI options remain platform-neutral.

## Verification

- Shell syntax checks pass for all macOS automation scripts.
- The CLI help smoke test passes.
- Changed files pass whitespace and privacy scans.
- Full upstream CI should provide the JavaFX-capable JDK required by the project.